### PR TITLE
feat: add copy-to-clipboard for storefront code blocks

### DIFF
--- a/io-storefront/src/app/components/io-button/api/page.tsx
+++ b/io-storefront/src/app/components/io-button/api/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SectionHeader, InlineCode, ApiTable, ReflectBadge } from '@/components/api/ApiPrimitives';
+import { CopyButton } from '@/components/CopyButton';
 
 
 // ── Page ──────────────────────────────────────────────────────────────────────
@@ -142,10 +143,27 @@ export default function IoButtonApiPage() {
           <p className="text-xs font-semibold mb-2" style={{ color: 'var(--io-text-muted)', letterSpacing: '0.04em' }}>
             Usage
           </p>
-          <pre
-            className="text-xs font-mono overflow-x-auto"
-            style={{ color: 'var(--io-text-secondary)', lineHeight: '1.7' }}
-          >
+          <div className="relative group">
+            <CopyButton
+              text={`// Vanilla JS
+document.querySelector('io-button')
+  .addEventListener('ioClick', (e) => console.log(e.detail));
+
+// React
+<IoButton onIoClick={(e) => console.log(e.detail)}>Click me</IoButton>
+
+// Angular
+<io-button (click)="handleClick($event)">Click me</io-button>
+
+// Vue
+<io-button @click="handleClick">Click me</io-button>`}
+              ariaLabel="Copy button events usage code"
+              className="absolute right-2 top-2 z-10"
+            />
+            <pre
+              className="text-xs font-mono overflow-x-auto pr-16"
+              style={{ color: 'var(--io-text-secondary)', lineHeight: '1.7' }}
+            >
 {`// Vanilla JS
 document.querySelector('io-button')
   .addEventListener('ioClick', (e) => console.log(e.detail));
@@ -158,7 +176,8 @@ document.querySelector('io-button')
 
 // Vue
 <io-button @click="handleClick">Click me</io-button>`}
-          </pre>
+            </pre>
+          </div>
         </div>
       </section>
 
@@ -189,10 +208,22 @@ document.querySelector('io-button')
           <p className="text-xs font-semibold mb-2" style={{ color: 'var(--io-text-muted)', letterSpacing: '0.04em' }}>
             Usage
           </p>
-          <pre
-            className="text-xs font-mono overflow-x-auto"
-            style={{ color: 'var(--io-text-secondary)', lineHeight: '1.7' }}
-          >
+          <div className="relative group">
+            <CopyButton
+              text={`// Vanilla JS
+const btn = document.querySelector('io-button');
+await btn.setFocus({ preventScroll: true });
+
+// React (via ref)
+const ref = useRef(null);
+await ref.current.setFocus();`}
+              ariaLabel="Copy button methods usage code"
+              className="absolute right-2 top-2 z-10"
+            />
+            <pre
+              className="text-xs font-mono overflow-x-auto pr-16"
+              style={{ color: 'var(--io-text-secondary)', lineHeight: '1.7' }}
+            >
 {`// Vanilla JS
 const btn = document.querySelector('io-button');
 await btn.setFocus({ preventScroll: true });
@@ -200,7 +231,8 @@ await btn.setFocus({ preventScroll: true });
 // React (via ref)
 const ref = useRef(null);
 await ref.current.setFocus();`}
-          </pre>
+            </pre>
+          </div>
         </div>
       </section>
 

--- a/io-storefront/src/app/page.tsx
+++ b/io-storefront/src/app/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { CopyButton } from '@/components/CopyButton';
 
 // ── Accent-bar section heading — io Digital signature ─────────────────────────
 
-function SectionHeading({ children, badge }: { children: React.ReactNode; badge?: string }) {
+function SectionHeading({ children, badge }: { children: ReactNode; badge?: string }) {
   return (
     <div className="flex items-center gap-3 mb-6">
       <span
@@ -170,12 +171,19 @@ export default function GettingStarted() {
             Built with Stencil and shipped as standard Web Components — works with React, Angular, Vue, or plain HTML.
           </p>
 
-          <pre
-            className="rounded-md px-4 py-3 text-sm overflow-x-auto"
-            style={{ background: 'var(--io-bg-surface)', color: '#d4d4d4' }}
-          >
-            <code>npm install @io-digital/components</code>
-          </pre>
+          <div className="relative group">
+            <CopyButton
+              text="npm install @io-digital/components"
+              ariaLabel="Copy quick start install command"
+              className="absolute right-3 top-3 z-10"
+            />
+            <pre
+              className="rounded-md px-4 py-3 pr-16 text-sm overflow-x-auto"
+              style={{ background: 'var(--io-bg-surface)', color: '#d4d4d4' }}
+            >
+              <code>npm install @io-digital/components</code>
+            </pre>
+          </div>
         </div>
 
         {/* Right: component name mosaic */}
@@ -221,12 +229,19 @@ export default function GettingStarted() {
                 <h3 className="font-semibold" style={{ color: 'var(--io-text-primary)' }}>
                   {title}
                 </h3>
-                <pre
-                  className="rounded-md p-4 text-sm overflow-x-auto"
-                  style={{ background: 'var(--io-bg-surface)', color: '#d4d4d4' }}
-                >
-                  <code>{code}</code>
-                </pre>
+                <div className="relative group">
+                  <CopyButton
+                    text={code}
+                    ariaLabel={`Copy code for step ${number}`}
+                    className="absolute right-3 top-3 z-10"
+                  />
+                  <pre
+                    className="rounded-md p-4 pr-16 text-sm overflow-x-auto"
+                    style={{ background: 'var(--io-bg-surface)', color: '#d4d4d4' }}
+                  >
+                    <code>{code}</code>
+                  </pre>
+                </div>
               </div>
             </div>
           ))}

--- a/io-storefront/src/components/CodeTabs.tsx
+++ b/io-storefront/src/components/CodeTabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
+import { CopyButton } from '@/components/CopyButton';
 
 export type CodeTab = { label: string; code: string };
 
@@ -27,17 +28,24 @@ export function CodeTabs({ tabs }: { tabs: CodeTab[] }) {
       </div>
 
       {/* Code panel */}
-      <pre
-        className="p-5 rounded-b-lg rounded-tr-lg text-sm font-mono overflow-x-auto leading-relaxed"
-        style={{
-          background: 'var(--io-bg-raised)',
-          border: '1px solid var(--io-border)',
-          borderTop: 'none',
-          color: 'var(--io-text-primary)',
-        }}
-      >
-        <code>{tabs[active].code}</code>
-      </pre>
+      <div className="relative group">
+        <CopyButton
+          text={tabs[active].code}
+          ariaLabel={`Copy ${tabs[active].label} code`}
+          className="absolute right-3 top-3 z-10"
+        />
+        <pre
+          className="p-5 pr-16 rounded-b-lg rounded-tr-lg text-sm font-mono overflow-x-auto leading-relaxed"
+          style={{
+            background: 'var(--io-bg-raised)',
+            border: '1px solid var(--io-border)',
+            borderTop: 'none',
+            color: 'var(--io-text-primary)',
+          }}
+        >
+          <code>{tabs[active].code}</code>
+        </pre>
+      </div>
     </div>
   );
 }

--- a/io-storefront/src/components/CopyButton.tsx
+++ b/io-storefront/src/components/CopyButton.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+type CopyButtonProps = {
+  text: string;
+  ariaLabel?: string;
+  className?: string;
+};
+
+const RESET_DELAY_MS = 2000;
+
+function CopyIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+function fallbackCopy(text: string) {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  textarea.style.pointerEvents = 'none';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+}
+
+export function CopyButton({ text, ariaLabel = 'Copy code', className }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        fallbackCopy(text);
+      }
+      setCopied(true);
+      if (resetTimeoutRef.current) {
+        clearTimeout(resetTimeoutRef.current);
+      }
+      resetTimeoutRef.current = setTimeout(() => {
+        setCopied(false);
+      }, RESET_DELAY_MS);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className={[
+          'inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium transition-colors cursor-pointer',
+          'border border-[var(--io-border)] bg-[var(--io-bg-raised)] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--io-border-focus)]',
+          'opacity-100 sm:opacity-0 sm:pointer-events-none sm:group-hover:opacity-100 sm:group-hover:pointer-events-auto sm:group-focus-within:opacity-100 sm:group-focus-within:pointer-events-auto',
+          copied
+            ? 'text-[var(--io-color-success)]'
+            : 'text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] hover:bg-[var(--io-bg-hover)]',
+        ].join(' ')}
+        aria-label={ariaLabel}
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+        <span>{copied ? 'Copied!' : 'Copy'}</span>
+      </button>
+      <span className="sr-only" aria-live="polite">
+        {copied ? 'Copied!' : ''}
+      </span>
+    </div>
+  );
+}

--- a/io-storefront/src/components/api/ApiPrimitives.tsx
+++ b/io-storefront/src/components/api/ApiPrimitives.tsx
@@ -1,4 +1,25 @@
-import type { ReactNode } from 'react';
+import { isValidElement, type ReactNode } from 'react';
+import { CopyButton } from '@/components/CopyButton';
+
+function nodeToText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') {
+    return '';
+  }
+
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node);
+  }
+
+  if (Array.isArray(node)) {
+    return node.map(nodeToText).join('');
+  }
+
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return nodeToText(node.props.children);
+  }
+
+  return '';
+}
 
 export function SectionHeader({ title, description }: { title: string; description: string }) {
   return (
@@ -127,6 +148,8 @@ export function EmptyNote({ children }: { children: ReactNode }) {
 }
 
 export function CodeNote({ label, children }: { label: string; children: ReactNode }) {
+  const codeText = nodeToText(children);
+
   return (
     <div
       className="rounded-lg p-4"
@@ -135,12 +158,15 @@ export function CodeNote({ label, children }: { label: string; children: ReactNo
       <p className="text-xs font-semibold mb-2" style={{ color: 'var(--io-text-muted)', letterSpacing: '0.04em' }}>
         {label}
       </p>
-      <pre
-        className="text-xs font-mono overflow-x-auto"
-        style={{ color: 'var(--io-text-secondary)', lineHeight: '1.7' }}
-      >
-        {children}
-      </pre>
+      <div className="relative group">
+        <CopyButton text={codeText} ariaLabel={`Copy ${label} code`} className="absolute right-2 top-2 z-10" />
+        <pre
+          className="text-xs font-mono overflow-x-auto pr-16"
+          style={{ color: 'var(--io-text-secondary)', lineHeight: '1.7' }}
+        >
+          {children}
+        </pre>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds a shared copy-to-clipboard affordance for storefront code blocks.

## Changes
- add shared CopyButton component with 2s success reset + aria-live="polite"
- integrate copy control in CodeTabs
- integrate copy control in API CodeNote shared primitive
- integrate copy control in homepage quick-start standalone code blocks
- integrate copy control in remaining standalone API pre snippets on button API page

## Validation
- [x] npm run type-check --workspace=io-storefront
- [x] npm run test --workspace=io-components (33 files / 190 tests)

Closes #2
