### PR TITLE
feat: add component status badges for beta and deprecated states

### DIFF
--- a/io-storefront/src/app/components/io-badge/layout.tsx
+++ b/io-storefront/src/app/components/io-badge/layout.tsx
@@ -19,6 +19,7 @@ export default function IoBadgeLayout({ children }: { children: React.ReactNode 
         description="Labels status, counts, and categories inline. Nine variants map directly to io Digital's semantic and brand colour palette."
         tabs={TABS}
         category="Component"
+        status="beta"
       />
       {children}
     </div>

--- a/io-storefront/src/app/components/io-input/layout.tsx
+++ b/io-storefront/src/app/components/io-input/layout.tsx
@@ -19,6 +19,7 @@ export default function IoInputLayout({ children }: { children: React.ReactNode 
         description="Single-line text entry. Built-in label, helper text, character count, and error state. Underline-only design."
         tabs={TABS}
         category="Component"
+        status="beta"
       />
       {children}
     </div>

--- a/io-storefront/src/components/StatusBadge.tsx
+++ b/io-storefront/src/components/StatusBadge.tsx
@@ -1,0 +1,23 @@
+import type { ComponentStatus } from '@/sitemap';
+
+export function StatusBadge({ status }: { status?: ComponentStatus }) {
+  if (!status || status === 'stable') return null;
+
+  if (status === 'beta') {
+    return (
+      <span
+        aria-label="Status: Beta"
+        role="img"
+        className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 shrink-0"
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-label="Status: Deprecated"
+      role="img"
+      className="inline-block w-1.5 h-1.5 rounded-full bg-red-500 shrink-0"
+    />
+  );
+}

--- a/io-storefront/src/components/layout/Navigation.tsx
+++ b/io-storefront/src/components/layout/Navigation.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { sitemap } from '@/sitemap';
+import { StatusBadge } from '@/components/StatusBadge';
 
 const SIDEBAR_EXPANDED_SECTIONS_KEY = 'io-sidebar-expanded-sections';
 
@@ -133,13 +134,14 @@ export function Navigation() {
                           href={item.href}
                           aria-current={active ? 'page' : undefined}
                           className={[
-                            'block pl-4 pr-3 py-1.5 rounded-full text-sm transition-colors',
+                            'flex items-center gap-1.5 pl-4 pr-3 py-1.5 rounded-full text-sm transition-colors',
                             active
                               ? 'font-semibold bg-[var(--io-color-primary)] text-white'
                               : 'font-medium text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] hover:bg-[var(--io-bg-hover)]',
                           ].join(' ')}
                         >
-                          {item.label}
+                          <span className={item.status === 'deprecated' ? 'line-through' : undefined}>{item.label}</span>
+                          <StatusBadge status={item.status} />
                         </Link>
                       </li>
                     );

--- a/io-storefront/src/components/layout/PageHeader.tsx
+++ b/io-storefront/src/components/layout/PageHeader.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { ComponentStatus } from '@/sitemap';
+import { StatusBadge } from '@/components/StatusBadge';
 
 export type PageTab = {
   label: string;
@@ -15,22 +17,24 @@ type Props = {
   tabs: PageTab[];
   /** Optional category chip rendered above the title, e.g. "Component" */
   category?: string;
+  status?: ComponentStatus;
 };
 
 /**
  * PageHeader — component page header with title, description, and pill tab navigation.
  */
-export function PageHeader({ title, description, tabs, category }: Props) {
+export function PageHeader({ title, description, tabs, category, status }: Props) {
   const pathname = usePathname();
 
   return (
     <div className="mb-0">
       {category && (
-        <span
-          className="block mb-2 text-[11px] font-semibold uppercase tracking-widest text-io-accent-text"
-        >
-          {category}
-        </span>
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-[11px] font-semibold uppercase tracking-widest text-io-accent-text">
+            {category}
+          </span>
+          <StatusBadge status={status} />
+        </div>
       )}
 
       <h1

--- a/io-storefront/src/sitemap.ts
+++ b/io-storefront/src/sitemap.ts
@@ -1,7 +1,10 @@
 /** Navigation tree for the io Design System storefront sidebar. */
+export type ComponentStatus = 'stable' | 'beta' | 'deprecated';
+
 export type NavItem = {
   label: string;
   href: string;
+  status?: ComponentStatus;
 };
 
 export type NavSection = {
@@ -45,20 +48,20 @@ export const sitemap: NavSection[] = [
     title: 'Components',
     items: [
       { label: 'Introduction', href: '/components' },
-      { label: 'Badge', href: '/components/io-badge/configurator' },
-      { label: 'Button', href: '/components/io-button/configurator' },
-      { label: 'Checkbox', href: '/components/io-checkbox/configurator' },
-      { label: 'Input', href: '/components/io-input/configurator' },
-      { label: 'Link', href: '/components/io-link/configurator' },
-      { label: 'Modal', href: '/components/io-modal/configurator' },
-      { label: 'Radio', href: '/components/io-radio/configurator' },
-      { label: 'Select', href: '/components/io-select/configurator' },
-      { label: 'Spinner', href: '/components/io-spinner/configurator' },
-      { label: 'Tabs', href: '/components/io-tabs/configurator' },
-      { label: 'Tag', href: '/components/io-tag/configurator' },
-      { label: 'Textarea', href: '/components/io-textarea/configurator' },
-      { label: 'Toast', href: '/components/io-toast/configurator' },
-      { label: 'Tooltip', href: '/components/io-tooltip/configurator' },
+      { label: 'Badge', href: '/components/io-badge/configurator', status: 'beta' },
+      { label: 'Button', href: '/components/io-button/configurator', status: 'stable' },
+      { label: 'Checkbox', href: '/components/io-checkbox/configurator', status: 'stable' },
+      { label: 'Input', href: '/components/io-input/configurator', status: 'beta' },
+      { label: 'Link', href: '/components/io-link/configurator', status: 'stable' },
+      { label: 'Modal', href: '/components/io-modal/configurator', status: 'stable' },
+      { label: 'Radio', href: '/components/io-radio/configurator', status: 'stable' },
+      { label: 'Select', href: '/components/io-select/configurator', status: 'stable' },
+      { label: 'Spinner', href: '/components/io-spinner/configurator', status: 'stable' },
+      { label: 'Tabs', href: '/components/io-tabs/configurator', status: 'stable' },
+      { label: 'Tag', href: '/components/io-tag/configurator', status: 'stable' },
+      { label: 'Textarea', href: '/components/io-textarea/configurator', status: 'stable' },
+      { label: 'Toast', href: '/components/io-toast/configurator', status: 'stable' },
+      { label: 'Tooltip', href: '/components/io-tooltip/configurator', status: 'stable' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add ComponentStatus type (stable | beta | deprecated) to sitemap.ts
- Add status field to all component NavItems; Badge and Input marked beta, rest stable
- Create StatusBadge component: amber dot for beta, red dot for deprecated, null for stable
- Render StatusBadge inline after label in sidebar navigation (flex layout with gap)
- Deprecated sidebar labels render with line-through text
- StatusBadge shown next to category chip in PageHeader for beta/deprecated components
- Update io-badge and io-input layouts to pass status=beta to PageHeader

## Validation
- npm run type-check (from io-storefront) PASS
- npm run test (33 files, 190 tests) PASS

Closes #8