### PR TITLE
feat: replace homepage chip grid with live component preview cards

### DIFF
--- a/io-storefront/src/app/page.tsx
+++ b/io-storefront/src/app/page.tsx
@@ -70,7 +70,7 @@ const ALL_COMPONENTS: Array<{
   },
   {
     name: 'Input', tag: 'io-input', href: '/components/io-input/configurator', status: 'beta',
-    preview: <io-input label="Label" placeholder="Enter text" />,
+    preview: <div className="w-full"><io-input label="Label" placeholder="Enter text" /></div>,
   },
   {
     name: 'Link', tag: 'io-link', href: '/components/io-link/configurator', status: 'stable',
@@ -86,7 +86,7 @@ const ALL_COMPONENTS: Array<{
   },
   {
     name: 'Select', tag: 'io-select', href: '/components/io-select/configurator', status: 'stable',
-    preview: <io-select label="Select" />,
+    preview: <div className="w-full"><io-select label="Colour" placeholder="Choose…" /></div>,
   },
   {
     name: 'Spinner', tag: 'io-spinner', href: '/components/io-spinner/configurator', status: 'stable',
@@ -94,7 +94,7 @@ const ALL_COMPONENTS: Array<{
   },
   {
     name: 'Tabs', tag: 'io-tabs', href: '/components/io-tabs/configurator', status: 'stable',
-    preview: <io-tabs tabs={[{id:'a',label:'Tab 1'},{id:'b',label:'Tab 2'}] as unknown} active-tab="a" />,
+    preview: <div className="w-full"><io-tabs tabs={[{id:'a',label:'Tab 1'},{id:'b',label:'Tab 2'}] as unknown} active-tab="a" /></div>,
   },
   {
     name: 'Tag', tag: 'io-tag', href: '/components/io-tag/configurator', status: 'stable',
@@ -102,11 +102,11 @@ const ALL_COMPONENTS: Array<{
   },
   {
     name: 'Textarea', tag: 'io-textarea', href: '/components/io-textarea/configurator', status: 'stable',
-    preview: <io-textarea label="Textarea" rows={2} />,
+    preview: <div className="w-full"><io-textarea label="Textarea" rows={2} /></div>,
   },
   {
     name: 'Toast', tag: 'io-toast', href: '/components/io-toast/configurator', status: 'stable',
-    preview: <io-badge variant="success">Notification</io-badge>,
+    preview: <io-badge variant="blue">Toast</io-badge>,
   },
   {
     name: 'Tooltip', tag: 'io-tooltip', href: '/components/io-tooltip/configurator', status: 'stable',

--- a/io-storefront/src/components/ComponentCard.tsx
+++ b/io-storefront/src/components/ComponentCard.tsx
@@ -19,7 +19,7 @@ export function ComponentCard({ name, href, status, children }: ComponentCardPro
       aria-label={`${name} – view configurator`}
       className="flex flex-col rounded-xl border border-[var(--io-border)] bg-[var(--io-bg-raised)] overflow-hidden transition-colors hover:bg-[var(--io-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--io-border-focus)]"
     >
-      <div className="flex-1 flex items-center justify-center p-6 min-h-[120px] pointer-events-none select-none">
+      <div className="flex-1 flex items-center justify-center p-6 min-h-[120px] w-full">
         {children}
       </div>
       <div className="px-4 py-3 border-t border-[var(--io-border)] flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add ComponentCard.tsx — a card with a live component preview area, component name, and StatusBadge; links to configurator
- replace the hero section chip mosaic (grid-cols-4 monospace tag chips) with a responsive ComponentCard grid
- all 14 components now render as interactive preview cards with representative default-state props

## Changes
- new: io-storefront/src/components/ComponentCard.tsx
- updated: io-storefront/src/app/page.tsx (ALL_COMPONENTS extended with status + preview JSX; hero restructured)

## Validation
- npm run type-check PASS
- npm run test PASS (33 files, 190 tests)

Closes #12
