### PR TITLE
[P4] Add visual spacing scale to design tokens page

### DIFF
--- a/io-storefront/src/app/styles/spacing/page.tsx
+++ b/io-storefront/src/app/styles/spacing/page.tsx
@@ -141,13 +141,13 @@ function SpacingRow({
         onClick={copy}
         aria-label={copied ? 'Copied!' : `Copy token ${token}`}
         title={copied ? 'Copied!' : 'Copy CSS custom property name'}
-        className="ml-auto shrink-0 rounded p-0.5"
+        className="ml-auto shrink-0 rounded-md w-7 h-7 flex items-center justify-center"
         style={{
           color: copied ? 'var(--io-color-success)' : 'var(--io-text-muted)',
-          background: 'transparent',
-          border: 'none',
+          background: copied ? 'var(--io-bg-hover)' : 'var(--io-bg-base)',
+          border: '1px solid var(--io-border)',
           cursor: 'pointer',
-          transition: 'color 150ms ease',
+          transition: 'color 150ms ease, background 150ms ease',
         }}
       >
         {copied ? (


### PR DESCRIPTION
## Summary
- add proportional visual bars for all spacing tokens in the spacing scale section
- show token name, rem value, and px value on each row
- add per-row copy icon button to copy CSS custom property names

## Validation
- npm run type-check
- npm run test

Closes #15