### PR TITLE
[P5] Transition and motion consistency pass

### DIFF
--- a/io-storefront/src/app/globals.css
+++ b/io-storefront/src/app/globals.css
@@ -107,3 +107,10 @@ code:not([class*="language-"]) {
 pre.react-syntax-highlighter-line-numbers {
   background: var(--io-bg-base) !important;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .io-decorative-transition {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/io-storefront/src/components/layout/Canvas.tsx
+++ b/io-storefront/src/components/layout/Canvas.tsx
@@ -133,7 +133,7 @@ export function Canvas({ children }: { children: ReactNode }) {
         <div className="flex items-center gap-3">
           <button
             onClick={toggleSidebarStart}
-            className="p-1.5 rounded hover:bg-[var(--io-bg-hover)] text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] transition-colors cursor-pointer"
+            className="p-1.5 rounded hover:bg-[var(--io-bg-hover)] text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] io-decorative-transition transition-colors duration-[var(--io-duration-fast)] cursor-pointer"
             aria-label={isSidebarStartOpen ? 'Close navigation' : 'Open navigation'}
           >
             <MenuIcon />
@@ -171,7 +171,7 @@ export function Canvas({ children }: { children: ReactNode }) {
               aria-label={`Set theme: ${t}`}
               aria-pressed={theme === t}
               className={[
-                'p-2 rounded-md transition-colors cursor-pointer',
+                'p-2 rounded-md io-decorative-transition transition-colors duration-[var(--io-duration-fast)] cursor-pointer',
                 theme === t
                   ? 'text-[var(--io-text-primary)] bg-[var(--io-bg-raised)]'
                   : 'text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] hover:bg-[var(--io-bg-hover)]',
@@ -186,7 +186,7 @@ export function Canvas({ children }: { children: ReactNode }) {
             href="https://github.com"
             target="_blank"
             rel="noreferrer"
-            className="p-1.5 rounded hover:bg-[var(--io-bg-hover)] text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] transition-colors"
+            className="p-1.5 rounded hover:bg-[var(--io-bg-hover)] text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] io-decorative-transition transition-colors duration-[var(--io-duration-fast)]"
             aria-label="GitHub"
           >
             <GithubIcon />

--- a/io-storefront/src/components/layout/Navigation.tsx
+++ b/io-storefront/src/components/layout/Navigation.tsx
@@ -156,7 +156,7 @@ export function Navigation() {
                   <span
                     aria-hidden="true"
                     className={[
-                      'text-xs leading-none transition-transform duration-200',
+                      'text-xs leading-none io-decorative-transition transition-transform duration-[var(--io-duration-normal)]',
                       isExpanded ? 'rotate-90' : 'rotate-0',
                     ].join(' ')}
                   >
@@ -175,7 +175,7 @@ export function Navigation() {
                           href={item.href}
                           aria-current={active ? 'page' : undefined}
                           className={[
-                            'flex items-center gap-1.5 pl-4 pr-3 py-1.5 rounded-full text-sm transition-colors',
+                            'flex items-center gap-1.5 pl-4 pr-3 py-1.5 rounded-full text-sm io-decorative-transition transition-colors duration-[var(--io-duration-fast)]',
                             active
                               ? 'font-semibold bg-[var(--io-color-primary)] text-white'
                               : 'font-medium text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)] hover:bg-[var(--io-bg-hover)]',

--- a/io-storefront/src/components/layout/PageHeader.tsx
+++ b/io-storefront/src/components/layout/PageHeader.tsx
@@ -77,7 +77,7 @@ export function PageHeader({ title, description, tabs, category, status }: Props
                   href={tab.href}
                   aria-current={isActive ? "page" : undefined}
                   className={[
-                    "rounded-lg px-4 py-1.5 text-sm transition-colors",
+                    "rounded-lg px-4 py-1.5 text-sm io-decorative-transition transition-colors duration-[var(--io-duration-normal)]",
                     isActive
                       ? "font-semibold bg-[var(--io-color-primary)] text-white shadow-sm"
                       : "font-medium text-[var(--io-text-secondary)] hover:text-[var(--io-text-primary)]",


### PR DESCRIPTION
## Summary
- standardize transition timings in scoped layout surfaces to `--io-duration-*` tokens
- replace hard-coded `duration-200` with tokenized normal duration
- add a reduced-motion media query that disables decorative transitions via a shared class hook

## Acceptance criteria
- [x] All transitions reference `--io-duration-*` tokens
- [x] No `transition-all` without an explicit duration
- [x] `@media (prefers-reduced-motion: reduce)` disables decorative transitions
- [x] `npm run test` passes

Closes #17
