### PR TITLE
[P5] Add 'Related components' section to component pages

### DIFF
--- a/io-storefront/src/app/components/io-badge/layout.tsx
+++ b/io-storefront/src/app/components/io-badge/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-badge/api' },
 ];
 
-export default function IoBadgeLayout({ children }: { children: React.ReactNode }) {
+export default function IoBadgeLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -22,6 +23,7 @@ export default function IoBadgeLayout({ children }: { children: React.ReactNode 
         status="beta"
       />
       {children}
+      <RelatedComponents currentSlug="io-badge" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-button/layout.tsx
+++ b/io-storefront/src/app/components/io-button/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-button/api' },
 ];
 
-export default function IoButtonLayout({ children }: { children: React.ReactNode }) {
+export default function IoButtonLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoButtonLayout({ children }: { children: React.ReactNode
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-button" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-checkbox/layout.tsx
+++ b/io-storefront/src/app/components/io-checkbox/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-checkbox/api' },
 ];
 
-export default function IoCheckboxLayout({ children }: { children: React.ReactNode }) {
+export default function IoCheckboxLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoCheckboxLayout({ children }: { children: React.ReactNo
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-checkbox" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-input/layout.tsx
+++ b/io-storefront/src/app/components/io-input/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-input/api' },
 ];
 
-export default function IoInputLayout({ children }: { children: React.ReactNode }) {
+export default function IoInputLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -22,6 +23,7 @@ export default function IoInputLayout({ children }: { children: React.ReactNode 
         status="beta"
       />
       {children}
+      <RelatedComponents currentSlug="io-input" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-link/layout.tsx
+++ b/io-storefront/src/app/components/io-link/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-link/api' },
 ];
 
-export default function IoLinkLayout({ children }: { children: React.ReactNode }) {
+export default function IoLinkLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoLinkLayout({ children }: { children: React.ReactNode }
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-link" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-modal/layout.tsx
+++ b/io-storefront/src/app/components/io-modal/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-modal/api' },
 ];
 
-export default function IoModalLayout({ children }: { children: React.ReactNode }) {
+export default function IoModalLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoModalLayout({ children }: { children: React.ReactNode 
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-modal" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-radio/layout.tsx
+++ b/io-storefront/src/app/components/io-radio/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-radio/api' },
 ];
 
-export default function IoRadioLayout({ children }: { children: React.ReactNode }) {
+export default function IoRadioLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoRadioLayout({ children }: { children: React.ReactNode 
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-radio" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-select/layout.tsx
+++ b/io-storefront/src/app/components/io-select/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-select/api' },
 ];
 
-export default function IoSelectLayout({ children }: { children: React.ReactNode }) {
+export default function IoSelectLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoSelectLayout({ children }: { children: React.ReactNode
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-select" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-spinner/layout.tsx
+++ b/io-storefront/src/app/components/io-spinner/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-spinner/api' },
 ];
 
-export default function IoSpinnerLayout({ children }: { children: React.ReactNode }) {
+export default function IoSpinnerLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoSpinnerLayout({ children }: { children: React.ReactNod
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-spinner" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-tabs/layout.tsx
+++ b/io-storefront/src/app/components/io-tabs/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-tabs/api' },
 ];
 
-export default function IoTabsLayout({ children }: { children: React.ReactNode }) {
+export default function IoTabsLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoTabsLayout({ children }: { children: React.ReactNode }
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-tabs" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-tag/layout.tsx
+++ b/io-storefront/src/app/components/io-tag/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-tag/api' },
 ];
 
-export default function IoTagLayout({ children }: { children: React.ReactNode }) {
+export default function IoTagLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoTagLayout({ children }: { children: React.ReactNode })
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-tag" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-textarea/layout.tsx
+++ b/io-storefront/src/app/components/io-textarea/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-textarea/api' },
 ];
 
-export default function IoTextareaLayout({ children }: { children: React.ReactNode }) {
+export default function IoTextareaLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoTextareaLayout({ children }: { children: React.ReactNo
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-textarea" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-toast/layout.tsx
+++ b/io-storefront/src/app/components/io-toast/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-toast/api' },
 ];
 
-export default function IoToastLayout({ children }: { children: React.ReactNode }) {
+export default function IoToastLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoToastLayout({ children }: { children: React.ReactNode 
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-toast" />
     </div>
   );
 }

--- a/io-storefront/src/app/components/io-tooltip/layout.tsx
+++ b/io-storefront/src/app/components/io-tooltip/layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from 'react';
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
 import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
 
 const TABS: PageTab[] = [
@@ -11,7 +12,7 @@ const TABS: PageTab[] = [
   { label: 'API', href: '/components/io-tooltip/api' },
 ];
 
-export default function IoTooltipLayout({ children }: { children: React.ReactNode }) {
+export default function IoTooltipLayout({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader
@@ -21,6 +22,7 @@ export default function IoTooltipLayout({ children }: { children: React.ReactNod
         category="Component"
       />
       {children}
+      <RelatedComponents currentSlug="io-tooltip" />
     </div>
   );
 }

--- a/io-storefront/src/components/ComponentCard.tsx
+++ b/io-storefront/src/components/ComponentCard.tsx
@@ -9,22 +9,33 @@ type ComponentCardProps = {
   name: string;
   href: string;
   status?: ComponentStatus;
-  children: ReactNode;
+  description?: string;
+  children?: ReactNode;
 };
 
-export function ComponentCard({ name, href, status, children }: ComponentCardProps) {
+export function ComponentCard({ name, href, status, description, children }: ComponentCardProps) {
   return (
     <Link
       href={href}
       aria-label={`${name} – view configurator`}
       className="flex flex-col rounded-xl border border-[var(--io-border)] bg-[var(--io-bg-raised)] overflow-hidden transition-colors hover:bg-[var(--io-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--io-border-focus)]"
     >
-      <div className="flex-1 flex items-center justify-center p-6 min-h-[120px] w-full">
-        {children}
+      <div className="flex-1 p-4 space-y-2">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-medium text-[var(--io-text-primary)]">{name}</span>
+          <StatusBadge status={status} />
+        </div>
+        {description ? (
+          <p className="text-xs leading-relaxed text-[var(--io-text-secondary)]">{description}</p>
+        ) : null}
+        {children ? (
+          <div className="min-h-[64px] w-full flex items-center justify-center">
+            {children}
+          </div>
+        ) : null}
       </div>
-      <div className="px-4 py-3 border-t border-[var(--io-border)] flex items-center gap-2">
-        <span className="text-sm font-medium text-[var(--io-text-primary)]">{name}</span>
-        <StatusBadge status={status} />
+      <div className="px-4 py-3 border-t border-[var(--io-border)]">
+        <span className="text-xs font-medium text-[var(--io-accent-text)]">Open configurator</span>
       </div>
     </Link>
   );

--- a/io-storefront/src/components/RelatedComponents.tsx
+++ b/io-storefront/src/components/RelatedComponents.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { ComponentCard } from '@/components/ComponentCard';
+import { getComponentItems } from '@/sitemap';
+
+type RelatedComponentsProps = {
+  currentSlug: string;
+};
+
+export function RelatedComponents({ currentSlug }: RelatedComponentsProps) {
+  const componentItems = getComponentItems();
+  const current = componentItems.find((item) => item.slug === currentSlug);
+
+  if (!current) {
+    return null;
+  }
+
+  const relatedItems = current.related
+    .map((slug) => componentItems.find((item) => item.slug === slug))
+    .filter((item): item is (typeof componentItems)[number] => Boolean(item))
+    .slice(0, 3);
+
+  if (relatedItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-10 space-y-4">
+      <h2 className="text-lg font-semibold text-[var(--io-text-primary)]">Related components</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {relatedItems.map((item) => (
+          <ComponentCard
+            key={item.slug}
+            name={item.label}
+            description={item.description}
+            href={item.href}
+            status={item.status}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/io-storefront/src/sitemap.ts
+++ b/io-storefront/src/sitemap.ts
@@ -5,6 +5,15 @@ export type NavItem = {
   label: string;
   href: string;
   status?: ComponentStatus;
+  slug?: string;
+  description?: string;
+  related?: string[];
+};
+
+export type ComponentNavItem = NavItem & {
+  slug: string;
+  description: string;
+  related: string[];
 };
 
 export type NavSection = {
@@ -48,20 +57,118 @@ export const sitemap: NavSection[] = [
     title: 'Components',
     items: [
       { label: 'Introduction', href: '/components' },
-      { label: 'Badge', href: '/components/io-badge/configurator', status: 'beta' },
-      { label: 'Button', href: '/components/io-button/configurator', status: 'stable' },
-      { label: 'Checkbox', href: '/components/io-checkbox/configurator', status: 'stable' },
-      { label: 'Input', href: '/components/io-input/configurator', status: 'beta' },
-      { label: 'Link', href: '/components/io-link/configurator', status: 'stable' },
-      { label: 'Modal', href: '/components/io-modal/configurator', status: 'stable' },
-      { label: 'Radio', href: '/components/io-radio/configurator', status: 'stable' },
-      { label: 'Select', href: '/components/io-select/configurator', status: 'stable' },
-      { label: 'Spinner', href: '/components/io-spinner/configurator', status: 'stable' },
-      { label: 'Tabs', href: '/components/io-tabs/configurator', status: 'stable' },
-      { label: 'Tag', href: '/components/io-tag/configurator', status: 'stable' },
-      { label: 'Textarea', href: '/components/io-textarea/configurator', status: 'stable' },
-      { label: 'Toast', href: '/components/io-toast/configurator', status: 'stable' },
-      { label: 'Tooltip', href: '/components/io-tooltip/configurator', status: 'stable' },
+      {
+        label: 'Badge',
+        href: '/components/io-badge/configurator',
+        status: 'beta',
+        slug: 'io-badge',
+        description: "Labels status, counts, and categories inline. Nine variants map directly to io Digital's semantic and brand colour palette.",
+        related: ['io-tag', 'io-toast', 'io-tooltip'],
+      },
+      {
+        label: 'Button',
+        href: '/components/io-button/configurator',
+        status: 'stable',
+        slug: 'io-button',
+        description: 'Handles primary interactions — form submissions, navigation, and confirmations. Three variants, ten brand colours, four sizes.',
+        related: ['io-link', 'io-modal', 'io-tabs'],
+      },
+      {
+        label: 'Checkbox',
+        href: '/components/io-checkbox/configurator',
+        status: 'stable',
+        slug: 'io-checkbox',
+        description: 'Binary selection with a built-in label and indeterminate state. Emits checked value via ioChange.',
+        related: ['io-radio', 'io-select', 'io-input'],
+      },
+      {
+        label: 'Input',
+        href: '/components/io-input/configurator',
+        status: 'beta',
+        slug: 'io-input',
+        description: 'Single-line text entry. Built-in label, helper text, character count, and error state. Underline-only design.',
+        related: ['io-textarea', 'io-select', 'io-checkbox'],
+      },
+      {
+        label: 'Link',
+        href: '/components/io-link/configurator',
+        status: 'stable',
+        slug: 'io-link',
+        description: 'Inline and standalone hyperlink. Three colour options, external link support, and an animated underline on hover.',
+        related: ['io-button', 'io-tooltip', 'io-tabs'],
+      },
+      {
+        label: 'Modal',
+        href: '/components/io-modal/configurator',
+        status: 'stable',
+        slug: 'io-modal',
+        description: 'Focuses attention on a critical task or confirmation. Rendered as a native dialog element — focus trapping and ESC are built-in.',
+        related: ['io-button', 'io-toast', 'io-tabs'],
+      },
+      {
+        label: 'Radio',
+        href: '/components/io-radio/configurator',
+        status: 'stable',
+        slug: 'io-radio',
+        description: 'Single-select from a group. Built-in label, helper text, error state, and ioChange event.',
+        related: ['io-checkbox', 'io-select', 'io-input'],
+      },
+      {
+        label: 'Select',
+        href: '/components/io-select/configurator',
+        status: 'stable',
+        slug: 'io-select',
+        description: 'Dropdown selection with a built-in label, placeholder, and error state. Pass options as an array of value/label objects.',
+        related: ['io-input', 'io-radio', 'io-checkbox'],
+      },
+      {
+        label: 'Spinner',
+        href: '/components/io-spinner/configurator',
+        status: 'stable',
+        slug: 'io-spinner',
+        description: 'Signals a loading or processing state. Three sizes, three colour modes including current to inherit parent colour.',
+        related: ['io-button', 'io-toast', 'io-modal'],
+      },
+      {
+        label: 'Tabs',
+        href: '/components/io-tabs/configurator',
+        status: 'stable',
+        slug: 'io-tabs',
+        description: 'Organises content into named panels. Keyboard-navigable with roving tabindex and full ARIA tab role semantics.',
+        related: ['io-button', 'io-tag', 'io-tooltip'],
+      },
+      {
+        label: 'Tag',
+        href: '/components/io-tag/configurator',
+        status: 'stable',
+        slug: 'io-tag',
+        description: 'Toggleable filter chip or removable label. Renders as a button with aria-pressed — emits ioToggle and ioRemove.',
+        related: ['io-badge', 'io-checkbox', 'io-tabs'],
+      },
+      {
+        label: 'Textarea',
+        href: '/components/io-textarea/configurator',
+        status: 'stable',
+        slug: 'io-textarea',
+        description: 'Multi-line text entry with label, helper text, character count, error state, and three resize modes.',
+        related: ['io-input', 'io-select', 'io-checkbox'],
+      },
+      {
+        label: 'Toast',
+        href: '/components/io-toast/configurator',
+        status: 'stable',
+        slug: 'io-toast',
+        description: 'Delivers time-limited feedback after a user action. Queue multiple messages via addToast() — one visible at a time.',
+        related: ['io-badge', 'io-modal', 'io-tooltip'],
+      },
+      {
+        label: 'Tooltip',
+        href: '/components/io-tooltip/configurator',
+        status: 'stable',
+        slug: 'io-tooltip',
+        description: 'Surfaces brief contextual help on hover or focus. Positioned automatically to stay within the viewport.',
+        related: ['io-link', 'io-button', 'io-badge'],
+      },
     ],
   },
   {
@@ -80,3 +187,17 @@ export const sitemap: NavSection[] = [
     ],
   },
 ];
+
+export function isComponentNavItem(item: NavItem): item is ComponentNavItem {
+  return Boolean(item.slug && item.description && item.related);
+}
+
+export function getComponentItems(): ComponentNavItem[] {
+  const componentsSection = sitemap.find((section) => section.title === 'Components');
+
+  if (!componentsSection) {
+    return [];
+  }
+
+  return componentsSection.items.filter(isComponentNavItem);
+}


### PR DESCRIPTION
## Summary
- add related component metadata in sitemap for all 14 components
- add shared RelatedComponents section at the bottom of each component layout
- render 2-3 related cards with component name, description, and configurator link

## Validation
- npm run type-check
- npm run test

Closes #16