### PR TITLE
[P2] Improve light-mode readability for configurator and sidebar labels

### DIFF
--- a/io-storefront/src/components/layout/Navigation.tsx
+++ b/io-storefront/src/components/layout/Navigation.tsx
@@ -149,7 +149,7 @@ export function Navigation() {
                 aria-expanded={isExpanded}
                 aria-controls={panelId}
                 onClick={() => { if (!trimmed) toggleSection(section.title); }}
-                className="w-full px-2 mb-1 inline-flex items-center justify-between text-[10px] font-bold uppercase tracking-widest text-[var(--io-text-muted)] hover:text-[var(--io-text-primary)]"
+                className="w-full px-2 mb-1 inline-flex items-center justify-between text-[10px] font-bold uppercase tracking-widest text-[var(--io-text-primary)] hover:text-[var(--io-text-primary)]"
               >
                 <span>{section.title}</span>
                 {!trimmed && (

--- a/io-storefront/src/components/playground/ConfiguratorControls.tsx
+++ b/io-storefront/src/components/playground/ConfiguratorControls.tsx
@@ -378,7 +378,7 @@ export function ConfiguratorControls({ propDefinitions, storyState, setStoryStat
           />
           <span
             className="text-[11px] font-semibold uppercase tracking-widest"
-            style={{ color: 'var(--io-text-muted)', letterSpacing: '0.1em' }}
+            style={{ color: 'var(--io-text-primary)', letterSpacing: '0.1em' }}
           >
             Properties
           </span>


### PR DESCRIPTION
## Summary
- Improve light-mode readability for configurator and sidebar primary labels
- Keep scope limited to the two targeted label locations from issue #35
- Document before/after contrast findings in the issue comment

## Changes
- `io-storefront/src/components/playground/ConfiguratorControls.tsx`
  - `Properties` heading token: `--io-text-muted` -> `--io-text-primary`
- `io-storefront/src/components/layout/Navigation.tsx`
  - Sidebar primary section labels token: `--io-text-muted` -> `--io-text-primary`

## Contrast audit (light mode)
- `#c4c4c4` on `#f7f7f7`: `1.63:1` (fail)
- `#242424` on `#f7f7f7`: `14.49:1` (pass)

Issue findings comment:
- https://github.com/iodigital-com/io-design-system/issues/35#issuecomment-4155307053

## Validation
- `npm run type-check` ✅
- `npm run test` ✅ (`33` files, `190` tests)

Closes #35
