### PR TITLE
[Breaking][Events] Add migration policy docs and regression guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed — Breaking events API policy (`MAJOR`)
+
+- Canonical event mapping is locked for the `io*` prefix removal migration:
+	- `ioInput` → `input`
+	- `ioChange` → `change`
+	- `ioFocus` → `focus`
+	- `ioBlur` → `blur`
+	- `ioOpen` → `open`
+	- `ioClose` → `close`
+	- `ioClick` → `click`
+	- `ioToggle` → `toggle`
+	- `ioRemove` → `remove`
+	- `ioToastDismiss` → `dismiss`
+- This migration is a hard breaking change and ships only in the next **major** release.
+- No dual-emit alias layer is provided.
+- Consumers must migrate listeners and wrapper props from `io*` / `onIo*` names to canonical names.
+
 ---
 
 ## [0.0.1] — 2026-03-27

--- a/README.md
+++ b/README.md
@@ -40,6 +40,31 @@ The storefront ([`io-storefront`](./io-storefront)) is a private Next.js documen
 
 ## Quick start
 
+### Event migration policy (breaking)
+
+The `io*` custom-event prefix has been removed in favor of canonical event names.
+This is a **major-version** breaking change with **no dual-emit alias layer**.
+
+Canonical mapping:
+
+- `ioInput` → `input`
+- `ioChange` → `change`
+- `ioFocus` → `focus`
+- `ioBlur` → `blur`
+- `ioOpen` → `open`
+- `ioClose` → `close`
+- `ioClick` → `click`
+- `ioToggle` → `toggle`
+- `ioRemove` → `remove`
+- `ioToastDismiss` → `dismiss`
+
+Wrapper/event binding examples:
+
+- React: `onIoChange` → `onChange`, `onIoClick` → `onClick`
+- Angular: `(ioChange)` → `(change)`, `(ioClick)` → `(click)`
+- Vue: `@io-change` → `@change`, `@io-click` → `@click`
+- Vanilla DOM: `addEventListener('ioChange', ...)` → `addEventListener('change', ...)`
+
 ### Vanilla HTML / CDN
 
 ```html

--- a/io-storefront/src/app/components/io-checkbox/api/page.tsx
+++ b/io-storefront/src/app/components/io-checkbox/api/page.tsx
@@ -126,7 +126,7 @@ document.querySelector('io-checkbox')
 <io-checkbox label="Accept terms" (change)="onCheck($event)"></io-checkbox>
 
 // Vue
-<io-checkbox label="Accept terms" @io-change="handleChange" />`}
+<io-checkbox label="Accept terms" @change="handleChange" />`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/components/io-input/api/page.tsx
+++ b/io-storefront/src/app/components/io-input/api/page.tsx
@@ -163,7 +163,7 @@ document.querySelector('io-input')
 <io-input (change)="handleChange($event)" label="Email"></io-input>
 
 // Vue
-<io-input @io-change="handleChange" label="Email" />`}
+<io-input @change="handleChange" label="Email" />`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/components/io-modal/api/page.tsx
+++ b/io-storefront/src/app/components/io-modal/api/page.tsx
@@ -97,7 +97,7 @@ openModal() { this.modal.nativeElement.show(); }
 
 // Vue
 const modal = ref(null);
-<io-modal ref="modal" heading="Confirm" @io-close="onClose">...</io-modal>
+<io-modal ref="modal" heading="Confirm" @close="onClose">...</io-modal>
 <button @click="modal?.show()">Open</button>`}
         </CodeNote>
       </section>
@@ -145,7 +145,7 @@ openModal() { this.modal.nativeElement.show(); }
 
 // Vue
 const modal = ref(null);
-<io-modal ref="modal" heading="Confirm" @io-close="onClose">...</io-modal>
+<io-modal ref="modal" heading="Confirm" @close="onClose">...</io-modal>
 <button @click="modal?.show()">Open</button>`}
         </CodeNote>
       </section>

--- a/io-storefront/src/app/components/io-radio/api/page.tsx
+++ b/io-storefront/src/app/components/io-radio/api/page.tsx
@@ -124,7 +124,7 @@ document.querySelectorAll('io-radio[name="delivery"]')
 <io-radio label="Express delivery" name="delivery" value="express" (change)="onDeliveryChange($event)"></io-radio>
 
 // Vue
-<io-radio label="Express delivery" name="delivery" value="express" @io-change="handleDeliveryChange" />`}
+<io-radio label="Express delivery" name="delivery" value="express" @change="handleDeliveryChange" />`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/components/io-select/api/page.tsx
+++ b/io-storefront/src/app/components/io-select/api/page.tsx
@@ -144,7 +144,7 @@ document.querySelector('io-select')
 <io-select label="Country" [options]="options" (change)="onSelect($event)"></io-select>
 
 // Vue
-<io-select label="Country" :options="options" @io-change="handleChange" />`}
+<io-select label="Country" :options="options" @change="handleChange" />`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/components/io-tabs/api/page.tsx
+++ b/io-storefront/src/app/components/io-tabs/api/page.tsx
@@ -104,7 +104,7 @@ document.querySelector('io-tabs')
 <io-tabs [tabs]="tabs" [activeTab]="activeTab" (change)="onTabChange($event)"></io-tabs>
 
 // Vue
-<io-tabs :tabs="tabs" :active-tab="activeTab" @io-change="handleChange" />`}
+<io-tabs :tabs="tabs" :active-tab="activeTab" @change="handleChange" />`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/components/io-tag/api/page.tsx
+++ b/io-storefront/src/app/components/io-tag/api/page.tsx
@@ -103,7 +103,7 @@ tag.addEventListener('remove', () => removeTag(tag));
 <io-tag (toggle)="onToggle($event)">React</io-tag>
 
 // Vue
-<io-tag @io-toggle="handleToggle">React</io-tag>`}
+<io-tag @toggle="handleToggle">React</io-tag>`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/components/io-textarea/api/page.tsx
+++ b/io-storefront/src/app/components/io-textarea/api/page.tsx
@@ -162,7 +162,7 @@ document.querySelector('io-textarea')
 <io-textarea label="Message" (change)="handleChange($event)"></io-textarea>
 
 // Vue
-<io-textarea label="Message" @io-change="handleChange" />`}
+<io-textarea label="Message" @change="handleChange" />`}
         </CodeNote>
       </section>
 

--- a/io-storefront/src/app/developing/vue/page.tsx
+++ b/io-storefront/src/app/developing/vue/page.tsx
@@ -130,7 +130,7 @@ function onEmailChange(event: CustomEvent<{ value: string }>) {
     label="Email address"
     type="email"
     :value="email"
-    @io-change="onEmailChange"
+    @change="onEmailChange"
   />
   <p>Current value: {{ email }}</p>
 </template>`}</CodeBlock>
@@ -234,7 +234,7 @@ describe('MyComponent', () => {
               Events not firing in templates
             </p>
             <p className="text-sm" style={{ color: 'var(--io-text-secondary)', lineHeight: '1.6' }}>
-              Custom element events use the <code>io-</code> prefix. Use <code>@io-change</code> rather than
+              Custom element events use canonical names. Use <code>@change</code> rather than
               the plain <code>@change</code> that native inputs emit. Consult the component API docs for the
               exact event names.
             </p>

--- a/package.json
+++ b/package.json
@@ -23,9 +23,10 @@
     "build:storefront": "npm --workspace @io-digital/storefront run build",
     "sync:stencil-assets": "node scripts/sync-stencil-assets.cjs",
     "governance:check": "node scripts/agency-validate-governance.cjs",
+    "events:guard": "node scripts/check-no-io-prefixed-events.cjs",
     "agents:install:claude": "node scripts/install-curated-agency-claude.cjs",
     "build:storefront:release": "npm run build:components && npm run sync:stencil-assets && npm run build:storefront",
-    "build:quality-gates": "npm run governance:check && npm run build && npm run test && npm run type-check && npm run build:storefront"
+    "build:quality-gates": "npm run governance:check && npm run events:guard && npm run build && npm run test && npm run type-check && npm run build:storefront"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/check-no-io-prefixed-events.cjs
+++ b/scripts/check-no-io-prefixed-events.cjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const root = process.cwd();
+
+const targets = [
+  'io-components/src/components',
+  'io-components-react/src',
+  'io-components-angular/src',
+  'io-components-vue/src',
+  'io-storefront/src',
+];
+
+const exts = new Set(['.ts', '.tsx', '.js', '.jsx', '.mdx']);
+
+const legacyEvents = [
+  'ioInput',
+  'ioChange',
+  'ioFocus',
+  'ioBlur',
+  'ioOpen',
+  'ioClose',
+  'ioClick',
+  'ioToggle',
+  'ioRemove',
+  'ioToastDismiss',
+];
+
+const eventLiteralPattern = new RegExp(`["'\\\`](${legacyEvents.join('|')})["'\\\`]`, 'g');
+const onIoPropPattern = /\bonIo[A-Z][A-Za-z0-9_]*\b/g;
+const decoratorPattern = /@Event\([^)]*\)\s*(ioInput|ioChange|ioFocus|ioBlur|ioOpen|ioClose|ioClick|ioToggle|ioRemove|ioToastDismiss)\b/g;
+const emitPattern = /\bthis\.(ioInput|ioChange|ioFocus|ioBlur|ioOpen|ioClose|ioClick|ioToggle|ioRemove|ioToastDismiss)\.emit\b/g;
+const angularBindingPattern = /\((ioInput|ioChange|ioFocus|ioBlur|ioOpen|ioClose|ioClick|ioToggle|ioRemove|ioToastDismiss)\)=/g;
+const vueBindingPattern = /@io-(input|change|focus|blur|open|close|click|toggle|remove|toast-dismiss)\b/g;
+
+const skipDirs = new Set(['node_modules', '.git', 'dist', 'coverage', '.next', 'www']);
+
+function walk(dir, out) {
+  const abs = path.join(root, dir);
+  if (!fs.existsSync(abs)) return;
+
+  for (const entry of fs.readdirSync(abs, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') && entry.name !== '.storybook') continue;
+    if (entry.isDirectory()) {
+      if (skipDirs.has(entry.name)) continue;
+      walk(path.join(dir, entry.name), out);
+      continue;
+    }
+
+    const ext = path.extname(entry.name);
+    if (!exts.has(ext)) continue;
+
+    out.push(path.join(dir, entry.name));
+  }
+}
+
+function findMatches(relPath) {
+  const absPath = path.join(root, relPath);
+  const text = fs.readFileSync(absPath, 'utf8');
+  const findings = [];
+
+  const checks = [
+    ['legacy event literal', eventLiteralPattern],
+    ['legacy onIo prop', onIoPropPattern],
+    ['legacy @Event name', decoratorPattern],
+    ['legacy emitter call', emitPattern],
+    ['legacy Angular binding', angularBindingPattern],
+    ['legacy Vue binding', vueBindingPattern],
+  ];
+
+  for (const [label, regex] of checks) {
+    regex.lastIndex = 0;
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      const index = match.index;
+      const line = text.slice(0, index).split('\n').length;
+      const lineText = text.split('\n')[line - 1].trim();
+      findings.push({ label, line, lineText });
+    }
+  }
+
+  return findings;
+}
+
+const files = [];
+for (const target of targets) {
+  walk(target, files);
+}
+
+const violations = [];
+for (const relPath of files) {
+  const matches = findMatches(relPath);
+  if (matches.length > 0) {
+    for (const match of matches) {
+      violations.push({ relPath, ...match });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('❌ Legacy io*-prefixed event references found:');
+  for (const violation of violations.slice(0, 80)) {
+    console.error(`- ${violation.relPath}:${violation.line} [${violation.label}] ${violation.lineText}`);
+  }
+  if (violations.length > 80) {
+    console.error(`...and ${violations.length - 80} more`);
+  }
+  process.exit(1);
+}
+
+console.log('✅ Event guard passed: no legacy io*-prefixed event API references found.');


### PR DESCRIPTION
Closes #67
Closes #75

## What changed
- Added explicit breaking-change policy for event migration in `CHANGELOG.md` (`Unreleased` section), including canonical old→new mapping and SemVer major-only rollout.
- Added a dedicated event migration section to root `README.md` with canonical mapping and framework-specific binding migrations (React/Angular/Vue/Vanilla).
- Added a regression guard script: `scripts/check-no-io-prefixed-events.cjs`.
- Wired guard into root scripts:
  - `events:guard`
  - `build:quality-gates` now runs `events:guard` before build/test/type-check.
- Fixed remaining legacy Vue event-binding examples in storefront docs (`@io-change`, `@io-close`, `@io-toggle` → canonical names).

## Why
- Issue #67 required a locked, visible policy source-of-truth for the event rename and release semantics.
- Issue #75 required a durable prevention mechanism so `io*` event APIs cannot be reintroduced in source/docs/tests.

## Files touched
- `CHANGELOG.md`
- `README.md`
- `package.json`
- `scripts/check-no-io-prefixed-events.cjs`
- `io-storefront/src/app/components/io-checkbox/api/page.tsx`
- `io-storefront/src/app/components/io-input/api/page.tsx`
- `io-storefront/src/app/components/io-modal/api/page.tsx`
- `io-storefront/src/app/components/io-radio/api/page.tsx`
- `io-storefront/src/app/components/io-select/api/page.tsx`
- `io-storefront/src/app/components/io-tabs/api/page.tsx`
- `io-storefront/src/app/components/io-tag/api/page.tsx`
- `io-storefront/src/app/components/io-textarea/api/page.tsx`
- `io-storefront/src/app/developing/vue/page.tsx`

## Acceptance checklist with evidence
- [x] #67: Canonical mapping documented
  - Added explicit mapping block in `CHANGELOG.md` and README event migration section.
- [x] #67: Major SemVer policy + no-alias decision documented
  - Added explicit “major release only” and “no dual-emit alias layer” statements in changelog + README.
- [x] #75: Regression guard exists and fails on legacy APIs
  - Added `scripts/check-no-io-prefixed-events.cjs` with checks for legacy literals, `onIo*`, old decorators/emits, Angular `(io...)`, and Vue `@io-...` bindings.
- [x] #75: Guard integrated into quality gates
  - Added `events:guard` script and included it in `build:quality-gates`.
- [x] #75: Core tests pass after guard/doc updates
  - `npm run test --workspace=io-components` → 33 files / 190 tests passed.

## Validation
- ✅ `npm run events:guard`
- ✅ `npm run test --workspace=io-components`
- ✅ `npm run build --workspace=io-components-angular`
- ✅ `npm run build --workspace=io-components-vue`
- ⚠️ `npm run build --workspace=io-components-react` fails with pre-existing generic typing errors in:
  - `io-components-react/src/react-component-lib/createOverlayComponent.tsx:140`
  - `io-components-react/src/react-component-lib/utils/index.tsx:40`

## Risks/notes
- This PR is scoped to issues #67 and #75 only.
- React wrapper build failure is pre-existing and unrelated to this PR’s event policy/guard changes; tracked as blocker evidence for issue #70 closure.
