### PR TITLE
fix(react): resolve wrapper forwardRef typing regressions

### DIFF
--- a/io-components-react/src/react-component-lib/createComponent.tsx
+++ b/io-components-react/src/react-component-lib/createComponent.tsx
@@ -12,7 +12,7 @@ interface StencilReactInternalProps<ElementType> extends React.HTMLAttributes<El
 }
 
 export const createReactComponent = <
-  PropType,
+  PropType extends object,
   ElementType extends HTMLStencilElement,
   ContextStateType = {},
   ExpandedPropsTypes = {}

--- a/io-components-react/src/react-component-lib/createOverlayComponent.tsx
+++ b/io-components-react/src/react-component-lib/createOverlayComponent.tsx
@@ -35,6 +35,7 @@ export const createOverlayComponent = <OverlayComponent extends object, OverlayT
     ReactOverlayProps & {
       forwardedRef?: StencilReactForwardedRef<OverlayType>;
     };
+  type ExternalProps = Omit<Props, 'forwardedRef'>;
 
   let isDismissing = false;
 
@@ -136,7 +137,8 @@ export const createOverlayComponent = <OverlayComponent extends object, OverlayT
     }
   }
 
-  return React.forwardRef<OverlayType, Props>((props, ref) => {
-    return <Overlay {...props} forwardedRef={ref} />;
+  return React.forwardRef<OverlayType, ExternalProps>((props, ref) => {
+    const overlayProps = { ...props, forwardedRef: ref } as unknown as Props;
+    return <Overlay {...overlayProps} />;
   });
 };

--- a/io-components-react/src/react-component-lib/utils/index.tsx
+++ b/io-components-react/src/react-component-lib/utils/index.tsx
@@ -28,16 +28,17 @@ export const mergeRefs = (
   };
 };
 
-export const createForwardRef = <PropType, ElementType>(ReactComponent: any, displayName: string) => {
+export const createForwardRef = <PropType extends object, ElementType>(ReactComponent: any, displayName: string) => {
+  type Props = StencilReactExternalProps<PropType, ElementType>;
   const forwardRef = (
-    props: StencilReactExternalProps<PropType, ElementType>,
-    ref: StencilReactForwardedRef<ElementType>
+    props: React.PropsWithoutRef<Props>,
+    ref: React.ForwardedRef<ElementType>
   ) => {
     return <ReactComponent {...props} forwardedRef={ref} />;
   };
   forwardRef.displayName = displayName;
 
-  return React.forwardRef(forwardRef);
+  return React.forwardRef<ElementType, Props>(forwardRef);
 };
 
 export const defineCustomElement = (tagName: string, customElement: any) => {


### PR DESCRIPTION
Closes #70

## Summary
- Fixes TypeScript generic mismatches in React wrapper forward-ref utilities.
- Aligns `createForwardRef` with `React.forwardRef` expected `PropsWithoutRef` signature.
- Constrains `createReactComponent` `PropType` to object to match helper contract.
- Fixes overlay wrapper ref handoff typing in `createOverlayComponent`.

## Files
- io-components-react/src/react-component-lib/createComponent.tsx
- io-components-react/src/react-component-lib/createOverlayComponent.tsx
- io-components-react/src/react-component-lib/utils/index.tsx

## Validation
- npm run build --workspace=io-components-react ✅
