### PR TITLE
feat(storefront): add story files for io-accordion, io-carousel, io-pagination

### DIFF
--- a/io-storefront/src/app/components/io-accordion/io-accordion.stories.ts
+++ b/io-storefront/src/app/components/io-accordion/io-accordion.stories.ts
@@ -1,0 +1,66 @@
+import type { Story } from '@/models/story';
+import type { PropDefinition } from '@/models/propDefinition';
+
+type IoAccordionItem = {
+  title: string;
+  body: string;
+  open?: boolean;
+};
+
+const SAMPLE_ITEMS: IoAccordionItem[] = [
+  {
+    title: 'Audits & research',
+    body: 'Making targeted, data-driven decisions starts with clear, reliable data...',
+    open: true,
+  },
+  {
+    title: 'Brand and communication strategy',
+    body: 'A clear brand and communication strategy gets you there...',
+  },
+  {
+    title: 'Digital strategy',
+    body: "You don't have to constantly reinvent yourself...",
+  },
+  {
+    title: 'Interface Design',
+    body: 'Great interfaces are invisible - they guide users effortlessly to their goal...',
+  },
+  {
+    title: 'Service design',
+    body: 'Service design connects people, processes, and technology into seamless experiences...',
+  },
+  {
+    title: 'UX strategy',
+    body: 'A clear UX strategy aligns user needs with business goals...',
+  },
+];
+
+export const accordionStory: Story<'io-accordion'> = {
+  state: { properties: { 'allow-multiple': false } },
+  generator: ({ properties } = {}) => [
+    {
+      tag: 'io-accordion' as const,
+      properties: {
+        items: SAMPLE_ITEMS,
+        'allow-multiple': properties?.['allow-multiple'] ?? false,
+      },
+    },
+  ],
+};
+
+export const accordionStoryAllowMultiple: Story<'io-accordion'> = {
+  state: { properties: { 'allow-multiple': true } },
+  generator: () => [
+    {
+      tag: 'io-accordion' as const,
+      properties: {
+        items: SAMPLE_ITEMS,
+        'allow-multiple': true,
+      },
+    },
+  ],
+};
+
+export const accordionPropDefinitions: PropDefinition[] = [
+  { name: 'allow-multiple', type: 'boolean', defaultValue: false },
+];

--- a/io-storefront/src/app/components/io-carousel/io-carousel.stories.ts
+++ b/io-storefront/src/app/components/io-carousel/io-carousel.stories.ts
@@ -1,0 +1,89 @@
+import type { Story } from '@/models/story';
+import type { PropDefinition } from '@/models/propDefinition';
+
+type IoCarouselItem = {
+  type: string;
+  title: string;
+  imageBackground?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+};
+
+const SLIDES_SHORT: IoCarouselItem[] = [
+  {
+    type: 'Blog',
+    title: 'Is AI taking over the customer journey?',
+    ctaLabel: 'Read more',
+    ctaHref: '#',
+  },
+  {
+    type: 'Webinar',
+    title: 'Cloud costs are skyrocketing - how to maintain control?',
+    ctaLabel: 'Watch now',
+    ctaHref: '#',
+  },
+  {
+    type: 'Event',
+    title: "Workshop: Together we'll make Drupal voor Overheden better",
+    ctaLabel: 'Register',
+    ctaHref: '#',
+  },
+  {
+    type: 'Webinar',
+    title: 'Beyond conversion rates: how digital experiences drive revenue',
+    ctaLabel: 'Watch now',
+    ctaHref: '#',
+  },
+];
+
+const SLIDES_FULL: IoCarouselItem[] = [
+  ...SLIDES_SHORT,
+  {
+    type: 'White paper',
+    title: 'Patient journey mapping in healthcare',
+    ctaLabel: 'Download',
+    ctaHref: '#',
+  },
+  {
+    type: 'White paper',
+    title: '7 strategic considerations for building powerful platforms',
+    ctaLabel: 'Download',
+    ctaHref: '#',
+  },
+  {
+    type: 'Webinar',
+    title: 'From mass marketing to audience of one: AI & data',
+    ctaLabel: 'Watch now',
+    ctaHref: '#',
+  },
+  {
+    type: 'Blog',
+    title: 'Pinterest ads: a channel worthy of discovery',
+    ctaLabel: 'Read more',
+    ctaHref: '#',
+  },
+];
+
+export const carouselStory: Story<'io-carousel'> = {
+  generator: () => [
+    {
+      tag: 'io-carousel' as const,
+      properties: {
+        items: SLIDES_SHORT,
+      },
+    },
+  ],
+};
+
+export const carouselStoryMore: Story<'io-carousel'> = {
+  generator: () => [
+    {
+      tag: 'io-carousel' as const,
+      properties: {
+        items: SLIDES_FULL,
+      },
+    },
+  ],
+};
+
+export const carouselPropDefinitions: PropDefinition[] = [];

--- a/io-storefront/src/app/components/io-pagination/io-pagination.stories.ts
+++ b/io-storefront/src/app/components/io-pagination/io-pagination.stories.ts
@@ -1,0 +1,37 @@
+import type { Story } from '@/models/story';
+import type { PropDefinition } from '@/models/propDefinition';
+
+// Default: page 1 of 5
+export const paginationStory: Story<'io-pagination'> = {
+  state: { properties: { page: 1, 'total-pages': 5 } },
+  generator: ({ properties } = {}) => [
+    {
+      tag: 'io-pagination' as const,
+      properties: {
+        page: properties?.page ?? 1,
+        'total-pages': properties?.['total-pages'] ?? 5,
+      },
+    },
+  ],
+};
+
+// Demonstrates ellipsis: active page in the middle of a large set
+export const paginationStoryMidRange: Story<'io-pagination'> = {
+  state: { properties: { page: 5, 'total-pages': 12 } },
+  generator: () => [
+    { tag: 'io-pagination' as const, properties: { page: 5, 'total-pages': 12 } },
+  ],
+};
+
+// All 7 pages visible - no ellipsis needed (total <= 7)
+export const paginationStoryFull: Story<'io-pagination'> = {
+  state: { properties: { page: 3, 'total-pages': 7 } },
+  generator: () => [
+    { tag: 'io-pagination' as const, properties: { page: 3, 'total-pages': 7 } },
+  ],
+};
+
+export const paginationPropDefinitions: PropDefinition[] = [
+  { name: 'page', type: 'number', defaultValue: 1 },
+  { name: 'total-pages', type: 'number', defaultValue: 5 },
+];


### PR DESCRIPTION
## Summary
- add io-pagination story exports for default, mid-range, and full-page scenarios
- add io-accordion story exports with sample data and allow-multiple toggle
- add io-carousel story exports for short and extended slide sets

## Validation
- npm run type-check

Closes #83