### PR TITLE
feat(storefront): io-accordion layout and 5 tab pages

### DIFF
--- a/io-storefront/src/app/components/io-accordion/accessibility/page.tsx
+++ b/io-storefront/src/app/components/io-accordion/accessibility/page.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { AriaTable, ComplianceCard, Kbd, KeyboardTable, RuleCard, SectionHeader } from '@/components/accessibility/AccessibilityPrimitives';
+
+export default function IoAccordionAccessibilityPage() {
+  return (
+    <div className="space-y-16">
+      <section id="keyboard-interaction" className="space-y-6">
+        <SectionHeader
+          title="Keyboard interaction"
+          description="Accordion triggers are native buttons and support disclosure toggling from keyboard input."
+        />
+        <KeyboardTable
+          rows={[
+            {
+              key: <Kbd>Tab</Kbd>,
+              action: 'Move focus to the next trigger button.',
+            },
+            {
+              key: <span className="flex items-center gap-1"><Kbd>Shift</Kbd><span style={{ color: 'var(--io-text-muted)' }}>+</span><Kbd>Tab</Kbd></span>,
+              action: 'Move focus to the previous trigger button.',
+            },
+            {
+              key: <span className="flex items-center gap-1"><Kbd>Enter</Kbd><span style={{ color: 'var(--io-text-muted)' }}>/</span><Kbd>Space</Kbd></span>,
+              action: 'Toggle the focused panel open or closed.',
+            },
+          ]}
+        />
+      </section>
+
+      <section id="aria" className="space-y-6">
+        <SectionHeader
+          title="ARIA"
+          description="Accordion exposes explicit relationships between trigger buttons and associated panel regions."
+        />
+        <AriaTable
+          rows={[
+            {
+              attribute: 'aria-expanded',
+              value: '<button>: "true" or "false"',
+              description: 'Current open or closed state of the panel controlled by that trigger.',
+            },
+            {
+              attribute: 'aria-controls',
+              value: '<button>: panel element ID',
+              description: 'Links trigger button to its corresponding panel element.',
+            },
+            {
+              attribute: 'role',
+              value: '<div> panel: "region"',
+              description: 'Identifies panel content as a landmark region.',
+            },
+            {
+              attribute: 'aria-labelledby',
+              value: '<div> panel: trigger button ID',
+              description: 'Associates panel region with its trigger label.',
+            },
+          ]}
+        />
+      </section>
+
+      <section id="wcag-compliance" className="space-y-6">
+        <SectionHeader
+          title="WCAG compliance"
+          description="Accordion implementation supports disclosure widget accessibility expectations, with one known semantic caveat noted below."
+        />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <ComplianceCard
+            criterion="1.3.1"
+            level="A"
+            title="Info and Relationships"
+            note="aria-expanded, aria-controls, role=region, and aria-labelledby expose structure programmatically."
+          />
+          <ComplianceCard
+            criterion="2.1.1"
+            level="A"
+            title="Keyboard"
+            note="All triggers are keyboard-operable using Enter and Space."
+          />
+          <ComplianceCard
+            criterion="2.4.7"
+            level="AA"
+            title="Focus Visible"
+            note="Trigger buttons display a visible focus ring via var(--io-focus-ring-active)."
+          />
+          <ComplianceCard
+            criterion="4.1.2"
+            level="A"
+            title="Name, Role, Value"
+            note="Interactive elements expose accessible names, roles, and state values to assistive technologies."
+          />
+        </div>
+      </section>
+
+      <section id="known-limitation" className="space-y-4">
+        <RuleCard label="Known limitation">
+          Arrow key navigation (Up/Down between triggers) is not implemented. This is acceptable for disclosure patterns but can be considered for future keyboard-heavy interfaces. Also, collapsed panel regions are visually hidden and should be verified with assistive technologies if stricter disclosure semantics are required.
+        </RuleCard>
+      </section>
+    </div>
+  );
+}

--- a/io-storefront/src/app/components/io-accordion/api/page.tsx
+++ b/io-storefront/src/app/components/io-accordion/api/page.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { ApiTable, EmptyNote, InlineCode, ReflectBadge, SectionHeader } from '@/components/api/ApiPrimitives';
+
+export default function IoAccordionApiPage() {
+  return (
+    <div className="space-y-16">
+      <section id="properties" className="space-y-4">
+        <SectionHeader
+          title="Properties"
+          description="Public props for io-accordion. Content is data-driven through the items array and open behavior is controlled with allow-multiple."
+        />
+        <ApiTable
+          columns={[
+            { label: 'Property', width: '170px' },
+            { label: 'Attribute', width: '170px' },
+            { label: 'Type', width: '220px' },
+            { label: 'Default', width: '120px' },
+            { label: 'Description' },
+          ]}
+          rows={[
+            [
+              <InlineCode key="property">items</InlineCode>,
+              <InlineCode key="attribute">-</InlineCode>,
+              <InlineCode key="type">IoAccordionItem[]</InlineCode>,
+              <InlineCode key="default">[]</InlineCode>,
+              <span key="description">Array of accordion entries. Set through JavaScript property.</span>,
+            ],
+            [
+              <span key="property"><InlineCode>allowMultiple</InlineCode><ReflectBadge /></span>,
+              <InlineCode key="attribute">allow-multiple</InlineCode>,
+              <InlineCode key="type">boolean</InlineCode>,
+              <InlineCode key="default">false</InlineCode>,
+              <span key="description">When true, multiple panels can be open at the same time.</span>,
+            ],
+          ]}
+        />
+      </section>
+
+      <section id="events" className="space-y-4">
+        <SectionHeader
+          title="Events"
+          description="Custom events emitted by io-accordion."
+        />
+        <ApiTable
+          columns={[
+            { label: 'Event', width: '190px' },
+            { label: 'Detail type', width: '220px' },
+            { label: 'Description' },
+          ]}
+          rows={[
+            [
+              <InlineCode key="event">accordionChange</InlineCode>,
+              <InlineCode key="detail">{`{ index: number; open: boolean }`}</InlineCode>,
+              <span key="description">Fires when a panel opens or closes.</span>,
+            ],
+          ]}
+        />
+      </section>
+
+      <section id="methods-slots" className="space-y-4">
+        <SectionHeader
+          title="Methods / Slots"
+          description="Imperative APIs and slots exposed by io-accordion."
+        />
+        <EmptyNote>
+          None. Content is data-driven via the <InlineCode>items</InlineCode> property.
+        </EmptyNote>
+      </section>
+
+      <section id="item-type" className="space-y-4">
+        <SectionHeader
+          title="IoAccordionItem type"
+          description="Shape of each item in the items array."
+        />
+        <ApiTable
+          columns={[
+            { label: 'Field', width: '170px' },
+            { label: 'Type', width: '170px' },
+            { label: 'Description' },
+          ]}
+          rows={[
+            [
+              <InlineCode key="field">title</InlineCode>,
+              <InlineCode key="type">string</InlineCode>,
+              <span key="description">Trigger text shown in the accordion header.</span>,
+            ],
+            [
+              <InlineCode key="field">body</InlineCode>,
+              <InlineCode key="type">string</InlineCode>,
+              <span key="description">Panel body text rendered when the item is open.</span>,
+            ],
+            [
+              <InlineCode key="field">open?</InlineCode>,
+              <InlineCode key="type">boolean</InlineCode>,
+              <span key="description">Initial open state. Defaults to false when omitted.</span>,
+            ],
+          ]}
+        />
+      </section>
+    </div>
+  );
+}

--- a/io-storefront/src/app/components/io-accordion/configurator/page.tsx
+++ b/io-storefront/src/app/components/io-accordion/configurator/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Configurator } from '@/components/playground/Configurator';
+import { accordionStory, accordionPropDefinitions } from '../io-accordion.stories';
+
+type AccordionItem = {
+  title: string;
+  body: string;
+  open?: boolean;
+};
+
+const SAMPLE_ITEMS: AccordionItem[] = [
+  {
+    title: 'Audits & research',
+    body: 'Making targeted, data-driven decisions starts with clear, reliable data...',
+    open: true,
+  },
+  {
+    title: 'Brand and communication strategy',
+    body: 'A clear brand and communication strategy gets you there...',
+  },
+  {
+    title: 'Digital strategy',
+    body: "You don't have to constantly reinvent yourself...",
+  },
+  {
+    title: 'Interface Design',
+    body: 'Great interfaces are invisible - they guide users effortlessly to their goal...',
+  },
+  {
+    title: 'Service design',
+    body: 'Service design connects people, processes, and technology into seamless experiences...',
+  },
+  {
+    title: 'UX strategy',
+    body: 'A clear UX strategy aligns user needs with business goals...',
+  },
+];
+
+export default function IoAccordionConfiguratorPage() {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const cloneItems = () => SAMPLE_ITEMS.map((item) => ({ ...item }));
+
+    const applyItems = () => {
+      root.querySelectorAll('io-accordion').forEach((el) => {
+        const accordionEl = el as HTMLElement & {
+          items?: AccordionItem[];
+          dataset: DOMStringMap;
+        };
+
+        // Set JS-only items once per element instance to avoid resetting panel state on every DOM mutation.
+        if (accordionEl.dataset.itemsBound === 'true') return;
+
+        accordionEl.items = cloneItems();
+        accordionEl.dataset.itemsBound = 'true';
+      });
+    };
+
+    applyItems();
+
+    const observer = new MutationObserver(() => {
+      applyItems();
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={rootRef}>
+      <Configurator
+        tagName="io-accordion"
+        story={accordionStory}
+        propDefinitions={accordionPropDefinitions}
+      />
+    </div>
+  );
+}

--- a/io-storefront/src/app/components/io-accordion/examples/page.tsx
+++ b/io-storefront/src/app/components/io-accordion/examples/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { ComponentStory } from '@/components/playground/ComponentStory';
+import { accordionStory, accordionStoryAllowMultiple } from '../io-accordion.stories';
+import { ExamplesSectionHeader } from '@/components/examples/ExamplesPrimitives';
+
+type AccordionItem = {
+  title: string;
+  body: string;
+  open?: boolean;
+};
+
+const SAMPLE_ITEMS: AccordionItem[] = [
+  {
+    title: 'Audits & research',
+    body: 'Making targeted, data-driven decisions starts with clear, reliable data...',
+    open: true,
+  },
+  {
+    title: 'Brand and communication strategy',
+    body: 'A clear brand and communication strategy gets you there...',
+  },
+  {
+    title: 'Digital strategy',
+    body: "You don't have to constantly reinvent yourself...",
+  },
+  {
+    title: 'Interface Design',
+    body: 'Great interfaces are invisible - they guide users effortlessly to their goal...',
+  },
+  {
+    title: 'Service design',
+    body: 'Service design connects people, processes, and technology into seamless experiences...',
+  },
+  {
+    title: 'UX strategy',
+    body: 'A clear UX strategy aligns user needs with business goals...',
+  },
+];
+
+export default function IoAccordionExamplesPage() {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const cloneItems = () => SAMPLE_ITEMS.map((item) => ({ ...item }));
+
+    const applyItems = () => {
+      root.querySelectorAll('io-accordion').forEach((el) => {
+        const accordionEl = el as HTMLElement & {
+          items?: AccordionItem[];
+          dataset: DOMStringMap;
+        };
+
+        // Set JS-only items once per element instance to avoid resetting panel state on every DOM mutation.
+        if (accordionEl.dataset.itemsBound === 'true') return;
+
+        accordionEl.items = cloneItems();
+        accordionEl.dataset.itemsBound = 'true';
+      });
+    };
+
+    applyItems();
+
+    const observer = new MutationObserver(() => {
+      applyItems();
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="space-y-10" ref={rootRef}>
+      <section>
+        <ExamplesSectionHeader
+          title="Single-open (default)"
+          description="Only one panel can be expanded at a time. Opening another panel closes the current one."
+        />
+        <ComponentStory story={accordionStory} />
+      </section>
+      <section>
+        <ExamplesSectionHeader
+          title="Multiple open"
+          description="With allow-multiple, multiple panels can be expanded simultaneously - useful for FAQ layouts."
+        />
+        <ComponentStory story={accordionStoryAllowMultiple} />
+      </section>
+    </div>
+  );
+}

--- a/io-storefront/src/app/components/io-accordion/layout.tsx
+++ b/io-storefront/src/app/components/io-accordion/layout.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { RelatedComponents } from '@/components/RelatedComponents';
+import { PageHeader, type PageTab } from '@/components/layout/PageHeader';
+
+const TABS: PageTab[] = [
+  { label: 'Configurator', href: '/components/io-accordion/configurator' },
+  { label: 'Examples', href: '/components/io-accordion/examples' },
+  { label: 'Usage', href: '/components/io-accordion/usage' },
+  { label: 'Accessibility', href: '/components/io-accordion/accessibility' },
+  { label: 'API', href: '/components/io-accordion/api' },
+];
+
+export default function IoAccordionLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <PageHeader
+        title="Accordion"
+        description="Collapsible content sections with animated plus/minus icon and title indent. Single-open by default; allow-multiple for FAQ-style patterns."
+        tabs={TABS}
+        category="Component"
+        status="beta"
+      />
+      {children}
+      <RelatedComponents currentSlug="io-accordion" />
+    </div>
+  );
+}

--- a/io-storefront/src/app/components/io-accordion/page.tsx
+++ b/io-storefront/src/app/components/io-accordion/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function IoAccordionPage() {
+  redirect('/components/io-accordion/configurator');
+}

--- a/io-storefront/src/app/components/io-accordion/usage/page.tsx
+++ b/io-storefront/src/app/components/io-accordion/usage/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { C, DoOrDontCard, RuleCard, SectionHeader, SubsectionTitle } from '@/components/usage/UsagePrimitives';
+
+export default function IoAccordionUsagePage() {
+  return (
+    <div className="space-y-16">
+      <section id="when-to-use" className="space-y-6">
+        <SectionHeader
+          title="When to use"
+          description="Use accordion when users need progressive disclosure without overwhelming the page with full-content blocks."
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-3">
+            <SubsectionTitle>Do</SubsectionTitle>
+            <DoOrDontCard type="do">
+              Use for FAQ sections, progressive disclosure of complex information, and reducing visual noise on dense content pages.
+            </DoOrDontCard>
+            <DoOrDontCard type="do">
+              Use single-open mode (default) when items are mutually exclusive or relate to a single decision.
+            </DoOrDontCard>
+            <DoOrDontCard type="do">
+              Use <C>allow-multiple</C> when users may need to compare information across multiple panels.
+            </DoOrDontCard>
+          </div>
+          <div className="space-y-3">
+            <SubsectionTitle>Don&apos;t</SubsectionTitle>
+            <DoOrDontCard type="dont">
+              Use an accordion to hide content that is critical to completing a task. That content should be visible by default.
+            </DoOrDontCard>
+            <DoOrDontCard type="dont">
+              Nest accordions inside accordion panels.
+            </DoOrDontCard>
+            <DoOrDontCard type="dont">
+              Use accordion as a navigation mechanism. Use <C>io-tabs</C> instead.
+            </DoOrDontCard>
+          </div>
+        </div>
+      </section>
+
+      <section id="behaviour" className="space-y-6">
+        <SectionHeader
+          title="Behaviour"
+          description="Accordion supports single-open and multi-open disclosure patterns with animated affordances for state change."
+        />
+        <div className="space-y-3">
+          <RuleCard label="Single-open (default)">
+            Opening a new panel automatically closes the currently open panel.
+          </RuleCard>
+          <RuleCard label="Multiple open (allow-multiple)">
+            Each panel toggles independently.
+          </RuleCard>
+          <RuleCard label="Animation">
+            Panel height animates from 0 to full via max-height transition; icon rotates from + to -.
+          </RuleCard>
+          <RuleCard label="Hover">
+            Trigger title shifts 1.2rem to the right on hover; icon scales to 0.7.
+          </RuleCard>
+        </div>
+      </section>
+
+      <section id="content-guidelines" className="space-y-6">
+        <SectionHeader
+          title="Content guidelines"
+          description="Write concise trigger labels and complete body copy to support scanability and readability."
+        />
+        <div className="space-y-3">
+          <RuleCard label="Title">
+            Keep titles to 3-8 words. Use noun phrases for category-style accordions (for example: Interface Design, not What is interface design?).
+          </RuleCard>
+          <RuleCard label="Body">
+            Write complete sentences and keep body copy up to roughly 680px max-width per the reference design.
+          </RuleCard>
+          <RuleCard label="CTA (optional)">
+            A standalone link can appear inside panel content when deeper reading is available.
+          </RuleCard>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add io-accordion layout and default redirect page
- add configurator and examples pages with imperative JS-only items binding via useEffect + ref
- add usage, accessibility, and api documentation pages using shared primitives only

## Validation
- npm run type-check
- npm run build:storefront

Closes #85