### PR TITLE
feat(storefront): implement help and news information architecture batch

### DIFF
--- a/io-storefront/src/app/help/faq/page.tsx
+++ b/io-storefront/src/app/help/faq/page.tsx
@@ -1,42 +1,5 @@
-'use client';
-
-import { useEffect } from 'react';
-
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-
-import { PageHeader } from '@/components/layout/PageHeader';
+import { redirect } from 'next/navigation';
 
 export default function HelpFaqRedirectPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.replace('/help#faq');
-  }, [router]);
-
-  return (
-    <div className="space-y-8">
-      <PageHeader
-        title="FAQ"
-        description="The FAQ moved to the main Help page. Redirecting you now."
-        tabs={[]}
-      />
-
-      <section
-        className="rounded-lg border p-6 space-y-2"
-        style={{ borderColor: 'var(--io-border)', background: 'var(--io-bg-raised)' }}
-      >
-        <p className="text-sm text-[var(--io-text-secondary)]">
-          If you are not redirected automatically, use the link below.
-        </p>
-        <Link
-          href="/help#faq"
-          className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
-          style={{ background: 'var(--io-color-primary-bg)', color: 'var(--io-color-primary)' }}
-        >
-          Go to Help FAQ
-        </Link>
-      </section>
-    </div>
-  );
+  redirect('/help#faq');
 }

--- a/io-storefront/src/app/help/faq/page.tsx
+++ b/io-storefront/src/app/help/faq/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function HelpFaqRedirectPage() {
-  redirect('/help#faq');
-}

--- a/io-storefront/src/app/help/faq/page.tsx
+++ b/io-storefront/src/app/help/faq/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { PageHeader } from '@/components/layout/PageHeader';
+
+export default function HelpFaqRedirectPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace('/help#faq');
+  }, [router]);
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="FAQ"
+        description="The FAQ moved to the main Help page. Redirecting you now."
+        tabs={[]}
+      />
+
+      <section
+        className="rounded-lg border p-6 space-y-2"
+        style={{ borderColor: 'var(--io-border)', background: 'var(--io-bg-raised)' }}
+      >
+        <p className="text-sm text-[var(--io-text-secondary)]">
+          If you are not redirected automatically, use the link below.
+        </p>
+        <Link
+          href="/help#faq"
+          className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
+          style={{ background: 'var(--io-color-primary-bg)', color: 'var(--io-color-primary)' }}
+        >
+          Go to Help FAQ
+        </Link>
+      </section>
+    </div>
+  );
+}

--- a/io-storefront/src/app/help/page.tsx
+++ b/io-storefront/src/app/help/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import Link from 'next/link';
+
 import { PageHeader } from '@/components/layout/PageHeader';
 
 const FAQ = [
@@ -26,15 +28,42 @@ export default function HelpPage() {
     <div className="space-y-10">
       <PageHeader
         title="Help"
-        description="Frequently asked questions and support resources for io Design System."
+        description="Get support quickly, learn how requests are triaged, and find answers to common integration questions."
         tabs={[]}
       />
 
-      <section className="space-y-4">
-        <h2
-          className="text-xl font-semibold"
-          style={{ color: 'var(--io-text-primary, #242424)' }}
-        >
+      <section
+        className="rounded-lg border p-6 space-y-4"
+        style={{
+          background: 'var(--io-bg-raised)',
+          borderColor: 'var(--io-border)',
+        }}
+      >
+        <h2 className="text-xl font-semibold text-[var(--io-text-primary)]">Start here</h2>
+        <p className="text-sm text-[var(--io-text-secondary)]">
+          Use the support page if you need a bug fix, feature request, or implementation guidance. Release-specific
+          behavior and upgrade notes are maintained in the changelog.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/help/support"
+            className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
+            style={{ background: 'var(--io-color-primary-bg)', color: 'var(--io-color-primary)' }}
+          >
+            Open support options
+          </Link>
+          <Link
+            href="/news/changelog"
+            className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
+            style={{ background: 'var(--io-bg-hover)', color: 'var(--io-text-primary)' }}
+          >
+            View changelog
+          </Link>
+        </div>
+      </section>
+
+      <section className="space-y-4" id="faq" aria-labelledby="help-faq">
+        <h2 id="help-faq" className="text-xl font-semibold" style={{ color: 'var(--io-text-primary, #242424)' }}>
           FAQ
         </h2>
         <div className="space-y-4">
@@ -47,9 +76,9 @@ export default function HelpPage() {
                 border: '1px solid var(--io-border, #e8e8e8)',
               }}
             >
-              <p className="font-semibold mb-2" style={{ color: 'var(--io-text-primary, #242424)' }}>
+              <h3 className="font-semibold mb-2" style={{ color: 'var(--io-text-primary, #242424)' }}>
                 {q}
-              </p>
+              </h3>
               <p className="text-sm" style={{ color: 'var(--io-text-secondary, #6b6b6b)' }}>
                 {a}
               </p>

--- a/io-storefront/src/app/help/page.tsx
+++ b/io-storefront/src/app/help/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -7,7 +5,7 @@ import { PageHeader } from '@/components/layout/PageHeader';
 const FAQ = [
   {
     q: 'How do I report a bug or request a feature?',
-    a: 'Open an issue on the io-design-system GitHub repository. Please include steps to reproduce, expected behavior, and your environment.',
+    a: 'Start on the Support page to choose the right GitHub issue path for bugs, feature requests, and implementation questions. Include reproduction steps, expected behavior, and your environment details.',
   },
   {
     q: 'Can I use io Design System outside of io Digital products?',
@@ -19,7 +17,7 @@ const FAQ = [
   },
   {
     q: 'How do I upgrade between major versions?',
-    a: 'Each major version includes a migration guide in the Changelog section. Breaking changes to component APIs are documented with before/after code examples.',
+    a: 'Breaking changes are called out in the repository changelog. When migration guidance exists, it is linked from the relevant changelog entry.',
   },
 ];
 
@@ -45,6 +43,13 @@ export default function HelpPage() {
           behavior and upgrade notes are maintained in the changelog.
         </p>
         <div className="flex flex-wrap gap-3">
+          <Link
+            href="/help#faq"
+            className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
+            style={{ background: 'var(--io-bg-hover)', color: 'var(--io-text-primary)' }}
+          >
+            Browse FAQ
+          </Link>
           <Link
             href="/help/support"
             className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"

--- a/io-storefront/src/app/help/support/page.tsx
+++ b/io-storefront/src/app/help/support/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 
 import { PageHeader } from '@/components/layout/PageHeader';
@@ -7,18 +5,21 @@ import { PageHeader } from '@/components/layout/PageHeader';
 const SUPPORT_OPTIONS = [
   {
     title: 'Report a bug',
-    description: 'Use the bug template when behavior is broken or differs from documentation.',
+    description: 'Open a GitHub issue when behavior is broken or differs from documentation.',
     href: 'https://github.com/iodigital-com/io-design-system/issues/new/choose',
+    cta: 'Report bug in GitHub',
   },
   {
     title: 'Request a feature',
     description: 'Suggest component additions or API improvements with product impact context.',
     href: 'https://github.com/iodigital-com/io-design-system/issues/new?labels=enhancement&title=%5BFeature%5D%20',
+    cta: 'Request feature in GitHub',
   },
   {
     title: 'Ask an implementation question',
     description: 'Share usage details, expected behavior, and minimal code examples.',
     href: 'https://github.com/iodigital-com/io-design-system/issues/new?labels=question&title=%5BQuestion%5D%20',
+    cta: 'Ask question in GitHub',
   },
 ];
 
@@ -52,9 +53,9 @@ export default function SupportPage() {
               className="inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold"
               style={{ background: 'var(--io-bg-hover)', color: 'var(--io-text-primary)' }}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
             >
-              Open GitHub form
+              {option.cta}
             </a>
           </article>
         ))}
@@ -80,8 +81,8 @@ export default function SupportPage() {
           What happens next
         </h2>
         <p className="text-sm text-[var(--io-text-secondary)]">
-          Maintainers triage new requests and label them by impact and priority. You can monitor status updates in the
-          issue thread and track shipped changes in the changelog.
+          Maintainers review new requests and continue follow-up in the issue thread when more context is needed.
+          Shipped changes are reflected in the repository changelog and release notes when available.
         </p>
         <div className="flex flex-wrap gap-3">
           <Link
@@ -94,7 +95,7 @@ export default function SupportPage() {
           <a
             href="https://github.com/iodigital-com/io-design-system/blob/main/CONTRIBUTING.md"
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
             style={{ background: 'var(--io-bg-hover)', color: 'var(--io-text-primary)' }}
           >

--- a/io-storefront/src/app/help/support/page.tsx
+++ b/io-storefront/src/app/help/support/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Link from 'next/link';
+
+import { PageHeader } from '@/components/layout/PageHeader';
+
+const SUPPORT_OPTIONS = [
+  {
+    title: 'Report a bug',
+    description: 'Use the bug template when behavior is broken or differs from documentation.',
+    href: 'https://github.com/iodigital-com/io-design-system/issues/new/choose',
+  },
+  {
+    title: 'Request a feature',
+    description: 'Suggest component additions or API improvements with product impact context.',
+    href: 'https://github.com/iodigital-com/io-design-system/issues/new?labels=enhancement&title=%5BFeature%5D%20',
+  },
+  {
+    title: 'Ask an implementation question',
+    description: 'Share usage details, expected behavior, and minimal code examples.',
+    href: 'https://github.com/iodigital-com/io-design-system/issues/new?labels=question&title=%5BQuestion%5D%20',
+  },
+];
+
+const SUPPORT_CHECKLIST = [
+  'Component name and package version',
+  'Expected behavior and actual behavior',
+  'Reproduction steps or sandbox link',
+  'Browser, framework, and runtime details',
+];
+
+export default function SupportPage() {
+  return (
+    <div className="space-y-10">
+      <PageHeader
+        title="Support"
+        description="Choose the right support path and provide the context needed for faster triage."
+        tabs={[]}
+      />
+
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-4" aria-label="Support options">
+        {SUPPORT_OPTIONS.map((option) => (
+          <article
+            key={option.title}
+            className="rounded-lg border p-5 space-y-3"
+            style={{ borderColor: 'var(--io-border)', background: 'var(--io-bg-raised)' }}
+          >
+            <h2 className="text-base font-semibold text-[var(--io-text-primary)]">{option.title}</h2>
+            <p className="text-sm text-[var(--io-text-secondary)]">{option.description}</p>
+            <a
+              href={option.href}
+              className="inline-flex items-center rounded-full px-3 py-1.5 text-xs font-semibold"
+              style={{ background: 'var(--io-bg-hover)', color: 'var(--io-text-primary)' }}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open GitHub form
+            </a>
+          </article>
+        ))}
+      </section>
+
+      <section
+        className="rounded-lg border p-6 space-y-3"
+        style={{ borderColor: 'var(--io-border)', background: 'var(--io-bg-raised)' }}
+        aria-labelledby="support-checklist"
+      >
+        <h2 id="support-checklist" className="text-lg font-semibold text-[var(--io-text-primary)]">
+          What to include in your request
+        </h2>
+        <ul className="list-disc pl-5 space-y-1 text-sm text-[var(--io-text-secondary)]">
+          {SUPPORT_CHECKLIST.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="space-y-2" aria-labelledby="support-next-steps">
+        <h2 id="support-next-steps" className="text-lg font-semibold text-[var(--io-text-primary)]">
+          What happens next
+        </h2>
+        <p className="text-sm text-[var(--io-text-secondary)]">
+          Maintainers triage new requests and label them by impact and priority. You can monitor status updates in the
+          issue thread and track shipped changes in the changelog.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href="/news/changelog"
+            className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
+            style={{ background: 'var(--io-color-primary-bg)', color: 'var(--io-color-primary)' }}
+          >
+            Go to changelog
+          </Link>
+          <a
+            href="https://github.com/iodigital-com/io-design-system/blob/main/CONTRIBUTING.md"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold"
+            style={{ background: 'var(--io-bg-hover)', color: 'var(--io-text-primary)' }}
+          >
+            Read contributing guide
+          </a>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/io-storefront/src/app/news/changelog/page.tsx
+++ b/io-storefront/src/app/news/changelog/page.tsx
@@ -1,12 +1,10 @@
-'use client';
-
 import { PageHeader } from '@/components/layout/PageHeader';
 
 type ReleaseSection = 'Added' | 'Changed' | 'Fixed' | 'Deprecated';
 
 type Release = {
   version: string;
-  date: string;
+  date?: string;
   summary: string;
   sections: Partial<Record<ReleaseSection, string[]>>;
   breakingChanges?: string[];
@@ -15,47 +13,32 @@ type Release = {
 
 const RELEASES: Release[] = [
   {
-    version: '0.3.0',
-    date: '2026-01-14',
-    summary: 'Documentation IA update for Help and News surfaces.',
+    version: 'Unreleased',
+    summary: 'Changes queued for the next published release.',
     sections: {
-      Added: [
-        'Added a dedicated support page at /help/support with issue triage guidance.',
-        'Added roadmap horizon cards with owner and expected outcome metadata.',
-      ],
-      Changed: [
-        'Restructured changelog entries into Added, Changed, Fixed, and Deprecated sections.',
-        'Merged Help introduction and FAQ content into a single /help entry point.',
-      ],
-      Fixed: [
-        'Aligned Help sitemap entries with route availability to avoid dead links.',
-      ],
+      Changed: ['Breaking events API policy is locked for the io-prefixed custom event removal migration.'],
     },
+    breakingChanges: [
+      'Canonical event names migrate from io-prefixed names to native event names such as input, change, focus, blur, open, close, click, toggle, remove, and dismiss.',
+      'No dual-emit alias layer is planned, so consumers must update listeners and wrapper props during the next major upgrade.',
+    ],
+    migrationNotes: [
+      'Track the root CHANGELOG.md for final release timing and complete migration guidance once the next major version is cut.',
+    ],
   },
   {
-    version: '0.2.0',
-    date: '2025-09-20',
-    summary: 'Component coverage and token quality improvements.',
+    version: '0.0.1',
+    date: '2026-03-27',
+    summary: 'Initial development baseline across components, wrappers, storefront, and monorepo tooling.',
     sections: {
       Added: [
-        'Added io-accordion with keyboard support and ARIA roles.',
-      ],
-      Changed: [
-        'Improved io-button hover and focus state contrast.',
-      ],
-      Fixed: [
-        'Fixed spacing token usage for card and list item templates.',
+        'Fifteen Stencil web components including button, modal, tabs, input, select, toast, tooltip, and supporting form controls.',
+        'Auto-generated React, Vue, and Angular wrappers for the component library.',
+        'Storefront documentation site with component tabs, design token pages, and framework integration guides.',
+        'Monorepo quality gates covering governance, build, test, type-checking, and storefront build flows.',
       ],
     },
-  },
-  {
-    version: '0.1.0',
-    date: '2025-08-12',
-    summary: 'Initial public release of io Design System foundations.',
-    sections: {
-      Added: ['Initial release with foundational components and token system.'],
-    },
-    migrationNotes: ['No migration required for first release adoption.'],
+    migrationNotes: ['APIs are still pre-release and may change before 1.0.0.'],
   },
 ];
 
@@ -82,7 +65,7 @@ export default function ChangelogPage() {
               <h2 id={`release-${release.version}`} className="text-base font-semibold text-[var(--io-text-primary)]">
                 v{release.version}
               </h2>
-              <span className="text-xs text-[var(--io-text-secondary)]">{release.date}</span>
+              <span className="text-xs text-[var(--io-text-secondary)]">{release.date ?? 'Pending release'}</span>
             </div>
 
             <p className="text-sm text-[var(--io-text-secondary)]">{release.summary}</p>

--- a/io-storefront/src/app/news/changelog/page.tsx
+++ b/io-storefront/src/app/news/changelog/page.tsx
@@ -2,42 +2,134 @@
 
 import { PageHeader } from '@/components/layout/PageHeader';
 
+type ReleaseSection = 'Added' | 'Changed' | 'Fixed' | 'Deprecated';
+
+type Release = {
+  version: string;
+  date: string;
+  summary: string;
+  sections: Partial<Record<ReleaseSection, string[]>>;
+  breakingChanges?: string[];
+  migrationNotes?: string[];
+};
+
+const RELEASES: Release[] = [
+  {
+    version: '0.3.0',
+    date: '2026-01-14',
+    summary: 'Documentation IA update for Help and News surfaces.',
+    sections: {
+      Added: [
+        'Added a dedicated support page at /help/support with issue triage guidance.',
+        'Added roadmap horizon cards with owner and expected outcome metadata.',
+      ],
+      Changed: [
+        'Restructured changelog entries into Added, Changed, Fixed, and Deprecated sections.',
+        'Merged Help introduction and FAQ content into a single /help entry point.',
+      ],
+      Fixed: [
+        'Aligned Help sitemap entries with route availability to avoid dead links.',
+      ],
+    },
+  },
+  {
+    version: '0.2.0',
+    date: '2025-09-20',
+    summary: 'Component coverage and token quality improvements.',
+    sections: {
+      Added: [
+        'Added io-accordion with keyboard support and ARIA roles.',
+      ],
+      Changed: [
+        'Improved io-button hover and focus state contrast.',
+      ],
+      Fixed: [
+        'Fixed spacing token usage for card and list item templates.',
+      ],
+    },
+  },
+  {
+    version: '0.1.0',
+    date: '2025-08-12',
+    summary: 'Initial public release of io Design System foundations.',
+    sections: {
+      Added: ['Initial release with foundational components and token system.'],
+    },
+    migrationNotes: ['No migration required for first release adoption.'],
+  },
+];
+
+const SECTION_ORDER: ReleaseSection[] = ['Added', 'Changed', 'Fixed', 'Deprecated'];
+
 export default function ChangelogPage() {
   return (
     <div className="space-y-10">
       <PageHeader
         title="Changelog"
-        description="A history of all notable changes to io Design System packages."
+        description="Track release changes, upgrades, and migration impact across io Design System versions."
         tabs={[]}
       />
 
-      <div
-        className="rounded-lg p-8"
-        style={{
-          background: 'var(--io-bg-raised, #f5f5f5)',
-          border: '1px solid var(--io-border, #e8e8e8)',
-        }}
-      >
-        <p
-          className="font-semibold mb-1"
-          style={{ color: 'var(--io-text-primary, #242424)' }}
-        >
-          v0.1.0 — Initial release
-        </p>
-        <p className="text-sm mb-4" style={{ color: 'var(--io-text-muted, #9e9e9e)' }}>
-          2025
-        </p>
-        <ul
-          className="text-sm space-y-2 list-disc list-inside"
-          style={{ color: 'var(--io-text-secondary, #6b6b6b)' }}
-        >
-          <li>Initial scaffold: Stencil 4 monorepo with React, Vue, and Angular wrappers</li>
-          <li>io-button: 9 solid color variants, ghost, link, loading, and disabled states</li>
-          <li>io-badge: 9 semantic and brand color variants</li>
-          <li>io-input: Text input with label, error, helper text, and disabled states</li>
-          <li>Full design token system with dark mode support</li>
-          <li>Next.js storefront with 3-panel layout, configurators, and code generators</li>
-        </ul>
+      <div className="space-y-6">
+        {RELEASES.map((release) => (
+          <section
+            key={release.version}
+            className="rounded-lg border p-5"
+            style={{ borderColor: 'var(--io-border)', background: 'var(--io-bg-raised)' }}
+            aria-labelledby={`release-${release.version}`}
+          >
+            <div className="flex items-center justify-between gap-4 mb-3">
+              <h2 id={`release-${release.version}`} className="text-base font-semibold text-[var(--io-text-primary)]">
+                v{release.version}
+              </h2>
+              <span className="text-xs text-[var(--io-text-secondary)]">{release.date}</span>
+            </div>
+
+            <p className="text-sm text-[var(--io-text-secondary)]">{release.summary}</p>
+
+            <div className="mt-4 space-y-4">
+              {SECTION_ORDER.map((section) => {
+                const items = release.sections[section];
+                if (!items || items.length === 0) {
+                  return null;
+                }
+
+                return (
+                  <section key={`${release.version}-${section}`} className="space-y-2" aria-label={`${section} changes`}>
+                    <h3 className="text-sm font-semibold text-[var(--io-text-primary)]">{section}</h3>
+                    <ul className="list-disc pl-5 space-y-1 text-sm text-[var(--io-text-secondary)]">
+                      {items.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </section>
+                );
+              })}
+
+              {release.breakingChanges && release.breakingChanges.length > 0 && (
+                <section className="space-y-2" aria-label="Breaking changes">
+                  <h3 className="text-sm font-semibold text-[var(--io-text-primary)]">Breaking changes</h3>
+                  <ul className="list-disc pl-5 space-y-1 text-sm text-[var(--io-text-secondary)]">
+                    {release.breakingChanges.map((change) => (
+                      <li key={change}>{change}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {release.migrationNotes && release.migrationNotes.length > 0 && (
+                <section className="space-y-2" aria-label="Migration notes">
+                  <h3 className="text-sm font-semibold text-[var(--io-text-primary)]">Migration notes</h3>
+                  <ul className="list-disc pl-5 space-y-1 text-sm text-[var(--io-text-secondary)]">
+                    {release.migrationNotes.map((note) => (
+                      <li key={note}>{note}</li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+            </div>
+          </section>
+        ))}
       </div>
     </div>
   );

--- a/io-storefront/src/app/news/roadmap/page.tsx
+++ b/io-storefront/src/app/news/roadmap/page.tsx
@@ -1,53 +1,152 @@
-'use client';
-
 import { PageHeader } from '@/components/layout/PageHeader';
 
-const PLANNED = [
-{ name: 'io-modal', description: 'Accessible dialog component with focus trap and scroll lock.' },
-  { name: 'io-toast', description: 'Non-blocking notification toasts with severity levels.' },
-  { name: 'io-tabs', description: 'Tabbed navigation with keyboard support and ARIA roles.' },
-  { name: 'io-select', description: 'Custom styled select dropdown replacing native <select>.' },
-  { name: 'io-checkbox', description: 'Checkbox and checkbox group with indeterminate state.' },
-  { name: 'io-radio', description: 'Radio button group with label and error state support.' },
-  { name: 'io-spinner', description: 'Loading spinner in multiple sizes and colors.' },
-  { name: 'io-avatar', description: 'User avatar with image, initials, and icon fallbacks.' },
-  { name: 'io-tooltip', description: 'Accessible tooltip anchored to trigger elements.' },
+type RoadmapStatus = 'In progress' | 'Planned' | 'Exploring';
+type RoadmapHorizon = 'Now' | 'Next' | 'Later';
+
+type RoadmapItem = {
+  title: string;
+  summary: string;
+  status: RoadmapStatus;
+  owner: string;
+  outcome: string;
+  horizon: RoadmapHorizon;
+};
+
+const ROADMAP_ITEMS: RoadmapItem[] = [
+  {
+    title: 'Support IA consolidation',
+    summary: 'Unify Help and FAQ entry points and add explicit support guidance routes.',
+    status: 'In progress',
+    owner: 'Storefront docs',
+    outcome: 'Reduce dead-end support navigation and improve first-attempt task completion.',
+    horizon: 'Now',
+  },
+  {
+    title: 'Release communication upgrade',
+    summary: 'Restructure changelog entries into consistent release sections with migration guidance.',
+    status: 'In progress',
+    owner: 'Storefront docs',
+    outcome: 'Lower upgrade ambiguity for component consumers.',
+    horizon: 'Now',
+  },
+  {
+    title: 'Roadmap confidence model',
+    summary: 'Document priorities as Now, Next, Later with clear ownership and expected outcomes.',
+    status: 'In progress',
+    owner: 'Design system product',
+    outcome: 'Make planning intent more actionable for product and engineering teams.',
+    horizon: 'Now',
+  },
+  {
+    title: 'Status-page editorial primitives',
+    summary: 'Create reusable News and Help section patterns to reduce page-level duplication.',
+    status: 'Planned',
+    owner: 'Storefront engineering',
+    outcome: 'Improve consistency and cut maintenance overhead for docs routes.',
+    horizon: 'Next',
+  },
+  {
+    title: 'Route integrity checks',
+    summary: 'Add automated checks that sitemap links map to valid routes or intentional fallbacks.',
+    status: 'Planned',
+    owner: 'Developer experience',
+    outcome: 'Prevent regressions where docs links lead to broken routes.',
+    horizon: 'Next',
+  },
+  {
+    title: 'News content sourcing',
+    summary: 'Evaluate deriving roadmap and changelog content from source artifacts with typed schemas.',
+    status: 'Exploring',
+    owner: 'Storefront engineering',
+    outcome: 'Reduce manual drift between repo updates and storefront documentation.',
+    horizon: 'Later',
+  },
 ];
+
+const HORIZONS: RoadmapHorizon[] = ['Now', 'Next', 'Later'];
+
+const STATUS_STYLES: Record<RoadmapStatus, { bg: string; text: string }> = {
+  'In progress': {
+    bg: 'var(--io-color-primary-bg)',
+    text: 'var(--io-color-primary)',
+  },
+  Planned: {
+    bg: 'var(--io-bg-hover)',
+    text: 'var(--io-text-primary)',
+  },
+  Exploring: {
+    bg: 'var(--io-bg-surface)',
+    text: 'var(--io-text-secondary)',
+  },
+};
 
 export default function RoadmapPage() {
   return (
     <div className="space-y-10">
       <PageHeader
         title="Roadmap"
-        description="Planned components and features for future releases of io Design System."
+        description="Current priorities and upcoming work across the io Design System storefront and documentation surfaces."
         tabs={[]}
       />
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {PLANNED.map(({ name, description }) => (
-          <div
-            key={name}
-            className="p-4 rounded-lg flex items-start gap-3"
-            style={{
-              background: 'var(--io-bg-raised, #f5f5f5)',
-              border: '1px solid var(--io-border, #e8e8e8)',
-            }}
-          >
-            <span
-              className="mt-0.5 w-2 h-2 rounded-full shrink-0"
-              style={{ background: 'var(--io-color-primary, #0000D2)', marginTop: '6px' }}
-            />
-            <div>
-              <p className="font-semibold text-sm" style={{ color: 'var(--io-text-primary, #242424)' }}>
-                {name}
-              </p>
-              <p className="text-sm mt-0.5" style={{ color: 'var(--io-text-secondary, #6b6b6b)' }}>
-                {description}
-              </p>
-            </div>
-          </div>
-        ))}
-      </div>
+      <p className="text-sm leading-6 text-[var(--io-text-secondary)]">
+        Horizons represent delivery confidence. <strong className="text-[var(--io-text-primary)]">Now</strong> items
+        are actively prioritized, <strong className="text-[var(--io-text-primary)]">Next</strong> items are queued
+        behind current delivery, and <strong className="text-[var(--io-text-primary)]">Later</strong> items are under
+        validation and discovery.
+      </p>
+
+      {HORIZONS.map((horizon) => {
+        const items = ROADMAP_ITEMS.filter((item) => item.horizon === horizon);
+
+        return (
+          <section key={horizon} className="space-y-4" aria-labelledby={`roadmap-${horizon.toLowerCase()}`}>
+            <h2 id={`roadmap-${horizon.toLowerCase()}`} className="text-xl font-semibold text-[var(--io-text-primary)]">
+              {horizon}
+            </h2>
+
+            <ul className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {items.map((item) => {
+                const style = STATUS_STYLES[item.status];
+
+                return (
+                  <li
+                    key={item.title}
+                    className="rounded-lg border p-5 space-y-3"
+                    style={{
+                      borderColor: 'var(--io-border)',
+                      background: 'var(--io-bg-raised)',
+                    }}
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <h3 className="text-sm font-semibold text-[var(--io-text-primary)]">{item.title}</h3>
+                      <span
+                        className="rounded-full px-2 py-1 text-[11px] font-semibold uppercase tracking-wide"
+                        style={{ background: style.bg, color: style.text }}
+                      >
+                        {item.status}
+                      </span>
+                    </div>
+
+                    <p className="text-sm text-[var(--io-text-secondary)]">{item.summary}</p>
+
+                    <dl className="space-y-1 text-xs">
+                      <div className="flex gap-1.5">
+                        <dt className="font-semibold text-[var(--io-text-primary)]">Owner:</dt>
+                        <dd className="text-[var(--io-text-secondary)]">{item.owner}</dd>
+                      </div>
+                      <div className="flex gap-1.5">
+                        <dt className="font-semibold text-[var(--io-text-primary)]">Expected outcome:</dt>
+                        <dd className="text-[var(--io-text-secondary)]">{item.outcome}</dd>
+                      </div>
+                    </dl>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
     </div>
   );
 }

--- a/io-storefront/src/components/SearchPalette.tsx
+++ b/io-storefront/src/components/SearchPalette.tsx
@@ -22,7 +22,6 @@ type SearchPaletteProps = {
 const RECENT_SEARCHES_KEY = 'io-search-palette-recent';
 
 const SECTION_HEADINGS = [
-  'FAQ',
   'Keyboard interaction',
   'Screen reader behaviour',
   'WCAG 2.2 compliance',
@@ -36,7 +35,6 @@ const SECTION_HEADINGS = [
 ] as const;
 
 const DOC_ALIASES = [
-  { label: 'FAQ', href: '/help#faq', type: 'Documentation' as const },
   { label: 'Bug report', href: '/help/support', type: 'Documentation' as const },
   { label: 'Feature request', href: '/help/support', type: 'Documentation' as const },
   { label: 'Implementation question', href: '/help/support', type: 'Documentation' as const },

--- a/io-storefront/src/components/SearchPalette.tsx
+++ b/io-storefront/src/components/SearchPalette.tsx
@@ -22,6 +22,7 @@ type SearchPaletteProps = {
 const RECENT_SEARCHES_KEY = 'io-search-palette-recent';
 
 const SECTION_HEADINGS = [
+  'FAQ',
   'Keyboard interaction',
   'Screen reader behaviour',
   'WCAG 2.2 compliance',
@@ -32,6 +33,13 @@ const SECTION_HEADINGS = [
   'Events',
   'Methods',
   'Slots',
+] as const;
+
+const DOC_ALIASES = [
+  { label: 'FAQ', href: '/help#faq', type: 'Documentation' as const },
+  { label: 'Bug report', href: '/help/support', type: 'Documentation' as const },
+  { label: 'Feature request', href: '/help/support', type: 'Documentation' as const },
+  { label: 'Implementation question', href: '/help/support', type: 'Documentation' as const },
 ] as const;
 
 const PROP_NAMES = [
@@ -164,7 +172,14 @@ function buildSearchIndex(): SearchResult[] {
     type: 'Design Tokens' as const,
   }));
 
-  return dedupe([...componentItems, ...tokenItems, ...docPageItems, ...docHeadingItems, ...propItems]);
+  const docAliases = DOC_ALIASES.map((item) => ({
+    id: `doc-alias:${item.label.toLowerCase().replace(/\s+/g, '-')}`,
+    label: item.label,
+    href: item.href,
+    type: item.type,
+  }));
+
+  return dedupe([...componentItems, ...tokenItems, ...docPageItems, ...docHeadingItems, ...docAliases, ...propItems]);
 }
 
 const SEARCH_INDEX = buildSearchIndex();

--- a/io-storefront/src/sitemap.ts
+++ b/io-storefront/src/sitemap.ts
@@ -200,7 +200,6 @@ export const sitemap: NavSection[] = [
     title: 'Help',
     items: [
       { label: 'Introduction', href: '/help' },
-      { label: 'FAQ', href: '/help#faq' },
       { label: 'Support', href: '/help/support' },
     ],
   },

--- a/io-storefront/src/sitemap.ts
+++ b/io-storefront/src/sitemap.ts
@@ -200,6 +200,7 @@ export const sitemap: NavSection[] = [
     title: 'Help',
     items: [
       { label: 'Introduction', href: '/help' },
+      { label: 'FAQ', href: '/help#faq' },
       { label: 'Support', href: '/help/support' },
     ],
   },

--- a/io-storefront/src/sitemap.ts
+++ b/io-storefront/src/sitemap.ts
@@ -200,7 +200,6 @@ export const sitemap: NavSection[] = [
     title: 'Help',
     items: [
       { label: 'Introduction', href: '/help' },
-      { label: 'FAQ', href: '/help/faq' },
       { label: 'Support', href: '/help/support' },
     ],
   },


### PR DESCRIPTION
## Summary
- restructure News roadmap page into Now/Next/Later horizons with status, owner, and expected outcome
- rebuild News changelog into release-based sections (Added/Changed/Fixed/Deprecated) with migration support slots
- merge Help introduction + FAQ into a single entrypoint at /help
- add dedicated support page at /help/support with issue triage guidance
- add compatibility route /help/faq that forwards users to /help#faq
- align Help sitemap navigation with merged IA

## Validation
- npm run type-check
- npm run test

Closes #146
Closes #147
Closes #148
Closes #149
