### PR TITLE
fix(io-icon): replace SVG sprite/use with inline path rendering

### DIFF
--- a/.changeset/fix-io-icon-inline-svg.md
+++ b/.changeset/fix-io-icon-inline-svg.md
@@ -1,0 +1,7 @@
+---
+"@iodigital-com/components": patch
+---
+
+fix(io-icon): switch from SVG sprite/use pattern to inline SVG path rendering
+
+The `<use href="#symbol">` pattern failed to render in Chrome when symbols were defined in a zero-size sprite container outside Shadow DOM. Icons now render their paths directly as inline SVG, eliminating the cross-document symbol reference issue.

--- a/io-components/src/components/io-icon/io-icon.tsx
+++ b/io-components/src/components/io-icon/io-icon.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, Prop, State, Watch, h } from '@stencil/core';
 
-import { ensureIconSymbol } from '../../utils/icon-sprite';
 import { ICON_NODES, escapeAttr } from '../../utils/icons';
 
 import { getIconStyles } from './io-icon-styles';
@@ -112,9 +111,8 @@ export class IoIcon {
       );
     }
 
-    if (!ICON_NODES[this.name]) return null;
-
-    ensureIconSymbol(this.name);
+    const nodes = ICON_NODES[this.name];
+    if (!nodes) return null;
 
     const ariaAttrs = this.label
       ? { role: 'img', 'aria-label': this.label }
@@ -123,8 +121,16 @@ export class IoIcon {
     return (
       <Host style={this.hostStyle}>
         <style>{getIconStyles()}</style>
-        <svg {...ariaAttrs}>
-          <use href={`#io-icon-${this.name}`} />
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          {...ariaAttrs}
+        >
+          {nodes.map(([tag, attrs]: [string, Record<string, string>]) => h(tag, attrs))}
         </svg>
       </Host>
     );


### PR DESCRIPTION
## Summary

- Replaces `<use href="#io-icon-{name}">` sprite pattern with direct inline SVG path rendering
- Root cause: Chrome does not resolve SVG symbol references from a zero-size hidden sprite container when `<use>` is inside Shadow DOM — icons rendered as empty boxes
- `ICON_NODES` paths now rendered directly in the `<svg>` element, eliminating the cross-shadow-root symbol reference entirely

## Test plan

- [ ] `npm run test` — 67 component + 1825 storefront tests pass
- [ ] `npm run build:components` — clean build
- [ ] Visual: icon configurator + examples grid show all 455 icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)