### PR TITLE
fix(storefront): align component preview canvases

### DIFF
--- a/.changeset/fix-io-flag-flagcdn-width-buckets.md
+++ b/.changeset/fix-io-flag-flagcdn-width-buckets.md
@@ -1,0 +1,5 @@
+---
+"@iodigital-com/components": patch
+---
+
+Fix io-flag requesting invalid flagcdn.com image widths. `getFlagSrc` now snaps arbitrary pixel sizes up to the nearest width flagcdn.com actually serves (20/40/80/160/320/640/1280/2560), preventing 404/ORB-blocked flag images at non-standard sizes.

--- a/io-components/src/components/io-flag/io-flag-utils.ts
+++ b/io-components/src/components/io-flag/io-flag-utils.ts
@@ -60,11 +60,18 @@ export function getFlagLabel(name: string, label?: string): string {
   return FLAG_COUNTRY_NAMES[name as IoFlagName] ?? name.toUpperCase();
 }
 
+/** Fixed set of pixel widths flagcdn.com actually serves; other widths 404/ORB-block. */
+const FLAGCDN_WIDTH_BUCKETS = [20, 40, 80, 160, 320, 640, 1280, 2560];
+
+/** Snaps an arbitrary pixel size up to the nearest width flagcdn.com serves. */
+function snapToFlagcdnWidth(sizePx: number): number {
+  return FLAGCDN_WIDTH_BUCKETS.find((bucket) => bucket >= sizePx) ?? FLAGCDN_WIDTH_BUCKETS[FLAGCDN_WIDTH_BUCKETS.length - 1];
+}
+
 /** Returns the CDN URL for a flag image using flagcdn.com. */
 export function getFlagSrc(name: string, sizePx: number): string {
-  // flagcdn.com serves country flags as PNG at standard widths.
-  // We use 40px as the canonical size for the 'md' slot.
-  return `https://flagcdn.com/w${sizePx}/${name.toLowerCase()}.png`;
+  // flagcdn.com only serves fixed width buckets — snap up to the nearest one.
+  return `https://flagcdn.com/w${snapToFlagcdnWidth(sizePx)}/${name.toLowerCase()}.png`;
 }
 
 /** Maps IoIconSize values to pixel widths for the flag image. */

--- a/io-components/src/components/io-flag/io-flag.spec.ts
+++ b/io-components/src/components/io-flag/io-flag.spec.ts
@@ -48,7 +48,15 @@ describe('io-flag — utils', () => {
     const src = getFlagSrc('nl', 24);
     expect(src).toContain('flagcdn.com');
     expect(src).toContain('nl');
-    expect(src).toContain('24');
+    expect(src).toContain('w40');
+  });
+
+  it('getFlagSrc snaps an arbitrary size up to the nearest flagcdn.com width bucket', () => {
+    expect(getFlagSrc('nl', 20)).toContain('w20');
+    expect(getFlagSrc('nl', 24)).toContain('w40');
+    expect(getFlagSrc('nl', 32)).toContain('w40');
+    expect(getFlagSrc('nl', 48)).toContain('w80');
+    expect(getFlagSrc('nl', 64)).toContain('w80');
   });
 
   it('FLAG_COUNTRY_NAMES has entries for all EU member states', () => {

--- a/io-storefront/src/app/components/io-button-tile/configurator/page.tsx
+++ b/io-storefront/src/app/components/io-button-tile/configurator/page.tsx
@@ -2,6 +2,7 @@
 
 import { buttonTileStory, buttonTilePropDefinitions } from '../io-button-tile.stories';
 import { Configurator } from '@/components/playground/Configurator';
+import { TILE_PREVIEW_CLASSNAME } from '@/components/playground/preview-styles';
 
 export default function IoButtonTileConfiguratorPage() {
   return (
@@ -9,6 +10,7 @@ export default function IoButtonTileConfiguratorPage() {
       tagName="io-button-tile"
       story={buttonTileStory}
       propDefinitions={buttonTilePropDefinitions}
+      previewClassName={TILE_PREVIEW_CLASSNAME}
     />
   );
 }

--- a/io-storefront/src/app/components/io-button-tile/examples/page.tsx
+++ b/io-storefront/src/app/components/io-button-tile/examples/page.tsx
@@ -4,6 +4,7 @@ import { buttonTileStoryStates } from '../io-button-tile.stories';
 
 import { ExamplesSectionHeader } from '@/components/examples/ExamplesPrimitives';
 import { ComponentStory } from '@/components/playground/ComponentStory';
+import { TILE_PREVIEW_CLASSNAME } from '@/components/playground/preview-styles';
 
 export default function IoButtonTileExamplesPage() {
   return (
@@ -14,7 +15,7 @@ export default function IoButtonTileExamplesPage() {
           title="States"
           description="Default, disabled, and loading states of the button tile."
         />
-        <ComponentStory story={buttonTileStoryStates} previewClassName="flex-wrap gap-4 items-start" />
+        <ComponentStory story={buttonTileStoryStates} previewClassName={`flex-wrap gap-4 items-start ${TILE_PREVIEW_CLASSNAME}`} />
       </section>
 
     </div>

--- a/io-storefront/src/app/components/io-input-password/examples/page.tsx
+++ b/io-storefront/src/app/components/io-input-password/examples/page.tsx
@@ -21,7 +21,7 @@ export default function IoInputPasswordExamplesPage() {
 
       <section>
         <ExamplesSectionHeader title="Sizes" description="sm, md, and lg sizes aligned with form control rhythm." />
-        <ComponentStory story={inputPasswordStorySizes} previewClassName="flex flex-wrap gap-4 items-end" />
+        <ComponentStory story={inputPasswordStorySizes} previewClassName="flex flex-wrap gap-4 items-end justify-center [&_io-input-password]:w-44 [&_io-input-password]:flex-none" />
       </section>
 
       <section>

--- a/io-storefront/src/app/components/io-link-tile/configurator/page.tsx
+++ b/io-storefront/src/app/components/io-link-tile/configurator/page.tsx
@@ -2,6 +2,7 @@
 
 import { linkTileStory, linkTilePropDefinitions } from '../io-link-tile.stories';
 import { Configurator } from '@/components/playground/Configurator';
+import { TILE_PREVIEW_CLASSNAME } from '@/components/playground/preview-styles';
 
 export default function IoLinkTileConfiguratorPage() {
   return (
@@ -9,6 +10,7 @@ export default function IoLinkTileConfiguratorPage() {
       tagName="io-link-tile"
       story={linkTileStory}
       propDefinitions={linkTilePropDefinitions}
+      previewClassName={TILE_PREVIEW_CLASSNAME}
     />
   );
 }

--- a/io-storefront/src/app/components/io-link-tile/examples/page.tsx
+++ b/io-storefront/src/app/components/io-link-tile/examples/page.tsx
@@ -4,6 +4,7 @@ import { linkTileStoryAspectRatios, linkTileStoryAlignments } from '../io-link-t
 
 import { ExamplesSectionHeader } from '@/components/examples/ExamplesPrimitives';
 import { ComponentStory } from '@/components/playground/ComponentStory';
+import { TILE_PREVIEW_CLASSNAME } from '@/components/playground/preview-styles';
 
 export default function IoLinkTileExamplesPage() {
   return (
@@ -14,7 +15,7 @@ export default function IoLinkTileExamplesPage() {
           title="Aspect ratios"
           description="Four built-in presets — 1:1, 4:3, 3:4, and 16:9. The tile always fills its container width."
         />
-        <ComponentStory story={linkTileStoryAspectRatios} previewClassName="flex-wrap gap-4 items-start" />
+        <ComponentStory story={linkTileStoryAspectRatios} previewClassName={`flex-wrap gap-4 items-start ${TILE_PREVIEW_CLASSNAME}`} />
       </section>
 
       <section>
@@ -22,7 +23,7 @@ export default function IoLinkTileExamplesPage() {
           title="Content alignment"
           description="The overlay content can be anchored to the top or bottom of the tile."
         />
-        <ComponentStory story={linkTileStoryAlignments} previewClassName="flex-wrap gap-4 items-start" />
+        <ComponentStory story={linkTileStoryAlignments} previewClassName={`flex-wrap gap-4 items-start ${TILE_PREVIEW_CLASSNAME}`} />
       </section>
 
     </div>

--- a/io-storefront/src/components/playground/preview-styles.ts
+++ b/io-storefront/src/components/playground/preview-styles.ts
@@ -17,3 +17,14 @@ export const FORM_FIELD_PREVIEW_STYLE: React.CSSProperties = {
   maxWidth: '400px',
   margin: '0 auto',
 };
+
+/**
+ * Shared preview-canvas class for io-button-tile / io-link-tile.
+ *
+ * Both components render `:host { display: block }` with every visible
+ * child absolutely positioned (media, overlay), so the host has no
+ * intrinsic size. Inside the Playground's flex preview canvas this
+ * collapses the host to 0×0. Give each tile instance an explicit width so
+ * `aspect-ratio` on the host has something to resolve against.
+ */
+export const TILE_PREVIEW_CLASSNAME = '[&_io-button-tile]:w-64 [&_io-link-tile]:w-64';


### PR DESCRIPTION
## Summary

Final pre-presentation visual QA sprint across all 58 storefront components' Configurator and Examples tabs (`io-design-system-showcase.web.app/components/*`), using Chrome DevTools MCP against a live browser. Hunted improper canvas alignment, blank/broken previews, awkward stretching, collapsed components, and unfinished examples. Fixed three root-cause defects — two in storefront preview layout, one in an io-flag CDN helper.

- **io-button-tile / io-link-tile — 0×0 preview collapse.** Both components render `:host { display: block }` with every visible child absolutely positioned, so the host has no intrinsic size. Inside the Playground's flex preview canvas this collapsed the tile to 0×0 (invisible). Added `TILE_PREVIEW_CLASSNAME` (`io-storefront/src/components/playground/preview-styles.ts`) giving each tile instance an explicit width so `aspect-ratio` has something to resolve against. Applied to `io-button-tile` and `io-link-tile` configurator + examples pages.
- **io-input-password Examples → Sizes — asymmetric centering.** The Small/Medium/Large row wasn't evenly spaced or centered against the canvas. Added `previewClassName="flex flex-wrap gap-4 items-end justify-center [&_io-input-password]:w-44 [&_io-input-password]:flex-none"` on that story.
- **io-flag — invalid flagcdn.com width requests.** `getFlagSrc` requested arbitrary pixel widths; flagcdn.com only serves fixed buckets (20/40/80/160/320/640/1280/2560) and 404s/ORB-blocks anything else, breaking flag images at non-default sizes. `getFlagSrc` now snaps up to the nearest valid bucket. Component-runtime change — last-resort, not storefront-only, but the bug is in the CDN URL builder, not styling/tokens/branding. Unit test updated to assert bucket-snapped output; patch changeset included.

**io-wordmark** configurator/examples appeared visually broken on the deployed showcase but render correctly against local dev — determined to be a stale production deployment, not a code defect. Recommend redeploying `main` to Firebase; no code change needed here.

All other components inspected were correctly aligned per the canvas rule (atomic → center-center, full-width/form → stretch, grouped controls → start, overlays → centered trigger, alignment-prop demos → dynamic).

## Evidence

Local screenshots + live bounding-rect/network-request verification under `audit/verify-*.png` (not committed — local QA evidence only):
- Tile collapse fix: confirmed 256×192 render (button-tile configurator + examples, link-tile examples, both aspect-ratio and alignment sections).
- io-input-password Sizes: confirmed even 192px pitch, symmetric centering.
- io-flag: confirmed via `list_network_requests` — all size variants (xs/md/xl) tested, all flagcdn requests return `200` with valid bucket widths (w40/w80).

## Test plan

- [x] `npm run governance:check` — pass
- [x] `npm run events:guard` — pass
- [x] `npm run lint` — 0 errors (504 pre-existing warnings, unrelated)
- [x] `npm run test` — 67 + 1825 tests pass
- [x] `npm run type-check` — pass
- [x] `npm run build:storefront` — static export succeeds
- [x] Forbidden-terms scan (Porsche/PDS/deprecated/legacy/superseded) on changed files — clean
- [x] Snapshot contamination check (`git diff main...HEAD -- "*.snap"`) — no diffs
- [x] Live re-verification of all 3 fixes via Chrome DevTools MCP against local dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)