### PR TITLE
docs(readme): sync component catalog with storefront sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,10 @@ This repository is responsible for all of the following:
 
 ## Component Catalog
 
-Current component set (58):
+Current component set (55):
 
 - io-accordion
 - io-ai-tag
-- io-app-shell
 - io-avatar
 - io-badge
 - io-banner
@@ -49,7 +48,6 @@ Current component set (58):
 - io-fieldset
 - io-flag
 - io-flyout
-- io-grid
 - io-heading
 - io-icon
 - io-inline-notification
@@ -76,7 +74,6 @@ Current component set (58):
 - io-spinner
 - io-stepper
 - io-switch
-- io-tab-panel
 - io-table
 - io-tabs
 - io-tabs-bar

--- a/README.md
+++ b/README.md
@@ -28,21 +28,28 @@ This repository is responsible for all of the following:
 
 ## Component Catalog
 
-Current component set (49):
+Current component set (58):
 
 - io-accordion
+- io-ai-tag
+- io-app-shell
 - io-avatar
 - io-badge
 - io-banner
 - io-breadcrumb
 - io-button
 - io-button-group
+- io-button-pure
+- io-button-tile
 - io-carousel
 - io-checkbox
 - io-checkbox-group
 - io-divider
 - io-drawer
+- io-fieldset
+- io-flag
 - io-flyout
+- io-grid
 - io-heading
 - io-icon
 - io-inline-notification
@@ -52,11 +59,13 @@ Current component set (49):
 - io-input-search
 - io-link
 - io-link-pure
+- io-link-tile
 - io-modal
 - io-multi-select
 - io-pagination
 - io-pin-code
 - io-popover
+- io-product-tile
 - io-progress
 - io-radio
 - io-radio-group


### PR DESCRIPTION
## Summary
- Root README's component catalog was stale vs `io-storefront/src/sitemap.ts` — missing 9 live components: io-ai-tag, io-app-shell, io-button-pure, io-button-tile, io-fieldset, io-flag, io-grid, io-link-tile, io-product-tile.
- Updates count 49 → 58.

## Note
`io-app-shell` and `io-tab-panel` both have full 5-tab storefront page directories and are registered in `custom-elements.d.ts`, but neither has a `sitemap.ts` nav entry — they're undiscoverable via the storefront sidebar. Flagging separately; not fixed here since it's a nav/behavior change, not a docs-text fix.

## Test plan
- [x] `npm run governance:check` passes
- [x] Docs-only change, no changeset needed